### PR TITLE
ChatEngine#$.created.chat, ChatEngine#$.created.user, ChatEngine#$.created.me events

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -207,6 +207,7 @@ module.exports = (ceConfig, pnConfig) => {
 
                     if (statusEvent.affectedChannels) {
                         statusEvent.affectedChannels.forEach((channel) => {
+
                             let chat = ChatEngine.chats[channel];
 
                             if (chat) {
@@ -217,6 +218,7 @@ module.exports = (ceConfig, pnConfig) => {
 
                                 // trigger the network events
                                 chat.trigger(eventName, statusEvent);
+
                             } else {
                                 ChatEngine._emit(eventName, statusEvent);
                             }

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -104,6 +104,17 @@ module.exports = (ceConfig, pnConfig) => {
 
         pnConfig.authKey = authKey || pnConfig.uuid;
 
+        let buildMe = () => {
+
+            // create a new user that represents this client
+            let me = new Me(ChatEngine, pnConfig.uuid, authData);
+            me.update(state);
+            me.onConstructed();
+
+            return me;
+
+        };
+
         let complete = (chatData) => {
 
             ChatEngine.pubnub = new PubNub(pnConfig);
@@ -112,9 +123,7 @@ module.exports = (ceConfig, pnConfig) => {
             // we don't do auth on this one because it's assumed to be done with the /auth request below
             ChatEngine.global = new Chat(ChatEngine, ceConfig.globalChannel, false, true, 'global');
 
-            // create a new user that represents this client
-            ChatEngine.me = new ChatEngine.Me(pnConfig.uuid, authData);
-            ChatEngine.me.update(state);
+            ChatEngine.me = buildMe();
 
             /**
              *  Fired when ChatEngine is connected to the internet and ready to go!
@@ -263,19 +272,6 @@ module.exports = (ceConfig, pnConfig) => {
                 ChatEngine.throwError(ChatEngine, '_emit', 'auth', new Error('There was a problem logging into the auth server (' + ceConfig.endpoint + ').'), { error });
             });
 
-    };
-
-    /**
-     * The {@link Me} class.
-     * @member {Me} Me
-     * @memberof ChatEngine
-     * @see {@link Me}
-     */
-    ChatEngine.Me = class extends Me {
-        constructor(...args) {
-            super(ChatEngine, ...args);
-            this.onConstructed();
-        }
     };
 
     /**

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -113,7 +113,7 @@ module.exports = (ceConfig, pnConfig) => {
             ChatEngine.global = new Chat(ChatEngine, ceConfig.globalChannel, false, true, 'global');
 
             // create a new user that represents this client
-            ChatEngine.me = new Me(ChatEngine, pnConfig.uuid, authData);
+            ChatEngine.me = new ChatEngine.Me(pnConfig.uuid, authData);
             ChatEngine.me.update(state);
 
             /**
@@ -266,6 +266,19 @@ module.exports = (ceConfig, pnConfig) => {
     };
 
     /**
+     * The {@link Me} class.
+     * @member {Me} Me
+     * @memberof ChatEngine
+     * @see {@link Me}
+     */
+    ChatEngine.Me = class extends Me {
+        constructor(...args) {
+            super(ChatEngine, ...args);
+            this.onConstructed();
+        }
+    };
+
+    /**
      * The {@link Chat} class.
      * @member {Chat} Chat
      * @memberof ChatEngine
@@ -274,6 +287,7 @@ module.exports = (ceConfig, pnConfig) => {
     ChatEngine.Chat = class extends Chat {
         constructor(...args) {
             super(ChatEngine, ...args);
+            this.onConstructed();
         }
     };
 
@@ -290,6 +304,7 @@ module.exports = (ceConfig, pnConfig) => {
                 return ChatEngine.me;
             } else {
                 super(ChatEngine, ...args);
+                this.onConstructed();
             }
 
         }

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -121,7 +121,7 @@ module.exports = (ceConfig, pnConfig) => {
 
             // create a new chat to use as global chat
             // we don't do auth on this one because it's assumed to be done with the /auth request below
-            ChatEngine.global = new Chat(ChatEngine, ceConfig.globalChannel, false, true, 'global');
+            ChatEngine.global = new ChatEngine.Chat(ceConfig.globalChannel, false, true, 'global');
 
             ChatEngine.me = buildMe();
 

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -104,17 +104,6 @@ module.exports = (ceConfig, pnConfig) => {
 
         pnConfig.authKey = authKey || pnConfig.uuid;
 
-        let buildMe = () => {
-
-            // create a new user that represents this client
-            let me = new Me(ChatEngine, pnConfig.uuid, authData);
-            me.update(state);
-            me.onConstructed();
-
-            return me;
-
-        };
-
         let complete = (chatData) => {
 
             ChatEngine.pubnub = new PubNub(pnConfig);
@@ -123,7 +112,10 @@ module.exports = (ceConfig, pnConfig) => {
             // we don't do auth on this one because it's assumed to be done with the /auth request below
             ChatEngine.global = new ChatEngine.Chat(ceConfig.globalChannel, false, true, 'global');
 
-            ChatEngine.me = buildMe();
+            // build the current user
+            ChatEngine.me = new Me(ChatEngine, pnConfig.uuid, authData);
+            ChatEngine.me.update(state);
+            ChatEngine.me.onConstructed();
 
             /**
              *  Fired when ChatEngine is connected to the internet and ready to go!

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -446,8 +446,6 @@ module.exports = class Chat extends Emitter {
 
         this.chatEngine.chats[this.channel] = this;
 
-        this.onConstructed();
-
     }
 
     /**

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -604,11 +604,12 @@ module.exports = class Chat extends Emitter {
             .then(() => {})
             .catch((error) => {
                 this.chatEngine.throwError(this, 'trigger', 'auth', new Error('Something went wrong while making a request to chat server.'), { error });
-                this.trigger('$.chat.left', { chat: this });
             });
 
 
         this.connected = false;
+
+        this.trigger('$.disconnected');
 
     }
 

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -446,7 +446,7 @@ module.exports = class Chat extends Emitter {
 
         this.chatEngine.chats[this.channel] = this;
 
-        this.bindProtoPlugins();
+        this.onConstructed();
 
     }
 

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -604,6 +604,7 @@ module.exports = class Chat extends Emitter {
             .then(() => {})
             .catch((error) => {
                 this.chatEngine.throwError(this, 'trigger', 'auth', new Error('Something went wrong while making a request to chat server.'), { error });
+                this.trigger('$.chat.left', { chat: this });
             });
 
 

--- a/src/components/me.js
+++ b/src/components/me.js
@@ -33,8 +33,6 @@ module.exports = class Me extends User {
             this.removeChatFromSession(payload.chat);
         });
 
-        this.onConstructed();
-
     }
 
     // assign updates from network

--- a/src/components/me.js
+++ b/src/components/me.js
@@ -33,7 +33,7 @@ module.exports = class Me extends User {
             this.removeChatFromSession(payload.chat);
         });
 
-        this.bindProtoPlugins();
+        this.onConstructed();
 
     }
 

--- a/src/components/me.js
+++ b/src/components/me.js
@@ -1,5 +1,4 @@
 const User = require('./user');
-const Chat = require('./chat');
 
 /**
  Represents the client connection as a special {@link User} with write permissions.
@@ -84,7 +83,7 @@ module.exports = class Me extends User {
             this.session[chat.group][chat.channel] = existingChat;
         } else {
             // otherwise, try to recreate it with the server information
-            this.session[chat.group][chat.channel] = new Chat(this.chatEngine, chat.channel, chat.private, false, chat.group);
+            this.session[chat.group][chat.channel] = new this.chatEngine.Chat(chat.channel, chat.private, false, chat.group);
 
             /**
             * Fired when another identical instance of {@link ChatEngine} and {@link Me} joins a {@link Chat} that this instance of {@link ChatEngine} is unaware of.

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -40,8 +40,6 @@ module.exports = class User extends Emitter {
          */
         this.state = {};
 
-        const Chat = require('../components/chat');
-
         /**
          * Feed is a Chat that only streams things a User does, like
          * 'startTyping' or 'idle' events for example. Anybody can subscribe
@@ -59,7 +57,7 @@ module.exports = class User extends Emitter {
          */
 
         // grants for these chats are done on auth. Even though they're marked private, they are locked down via the server
-        this.feed = new Chat(chatEngine, [chatEngine.global.channel, 'user', uuid, 'read.', 'feed'].join('#'), false, this.constructor.name === 'Me', 'feed');
+        this.feed = new this.chatEngine.Chat([chatEngine.global.channel, 'user', uuid, 'read.', 'feed'].join('#'), false, this.constructor.name === 'Me', 'feed');
 
         /**
          * Direct is a private channel that anybody can publish to but only
@@ -80,7 +78,7 @@ module.exports = class User extends Emitter {
          * them.direct.connect();
          * them.direct.emit('private-message', {secret: 42});
          */
-        this.direct = new Chat(chatEngine, [chatEngine.global.channel, 'user', uuid, 'write.', 'direct'].join('#'), false, this.constructor.name === 'Me', 'direct');
+        this.direct = new this.chatEngine.Chat([chatEngine.global.channel, 'user', uuid, 'write.', 'direct'].join('#'), false, this.constructor.name === 'Me', 'direct');
 
         // if the user does not exist at all and we get enough
         // information to build the user

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -91,8 +91,6 @@ module.exports = class User extends Emitter {
         // update this user's state in it's created context
         this.assign(state);
 
-        this.onConstructed();
-
     }
 
     /**

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -91,7 +91,7 @@ module.exports = class User extends Emitter {
         // update this user's state in it's created context
         this.assign(state);
 
-        this.bindProtoPlugins();
+        this.onConstructed();
 
     }
 

--- a/src/modules/emitter.js
+++ b/src/modules/emitter.js
@@ -227,6 +227,7 @@ module.exports = class Emitter extends RootEmitter {
         this.onConstructed = () => {
 
             this.bindProtoPlugins();
+            this.trigger('$.created');
 
         };
 

--- a/src/modules/emitter.js
+++ b/src/modules/emitter.js
@@ -28,10 +28,7 @@ module.exports = class Emitter extends RootEmitter {
 
             // all events are forwarded to ChatEngine object
             // so you can globally bind to events with ChatEngine.on()
-            if (typeof data === 'object' && !data.source) {
-                data.source = this;
-                this.chatEngine._emit(event, data);
-            }
+            this.chatEngine._emit(event, data, this);
 
 
             // emit the event from the object that created it

--- a/src/modules/emitter.js
+++ b/src/modules/emitter.js
@@ -24,11 +24,15 @@ module.exports = class Emitter extends RootEmitter {
          @private
          @param {String} event The event payload object
          */
-        this._emit = (event, data) => {
+        this._emit = (event, data = {}) => {
 
             // all events are forwarded to ChatEngine object
             // so you can globally bind to events with ChatEngine.on()
-            this.chatEngine._emit(event, data);
+            if (typeof data === 'object' && !data.source) {
+                data.source = this;
+                this.chatEngine._emit(event, data);
+            }
+
 
             // emit the event from the object that created it
             this.emitter.emit(event, data);
@@ -220,16 +224,9 @@ module.exports = class Emitter extends RootEmitter {
 
         };
 
-        this.onCreated = () => {
-            let data = {};
-            data[this.name.toLowerCase()] = this;
-            this.trigger(['$', this.name.toLowerCase(), 'created'], data);
-        };
-
         this.onConstructed = () => {
 
             this.bindProtoPlugins();
-            this.onCreated();
 
         };
 

--- a/src/modules/emitter.js
+++ b/src/modules/emitter.js
@@ -226,17 +226,6 @@ module.exports = class Emitter extends RootEmitter {
             this.trigger(['$', this.name.toLowerCase(), 'created'], data);
         };
 
-        this.onDeleted = () => {
-            let data = {};
-            data[this.name.toLowerCase()] = this;
-            this.trigger(['$', this.name.toLowerCase(), 'deleted'], data);
-        };
-
-        this.delete = () => {
-            this.emitter.removeAllListeners();
-            this.onDeleted();
-        };
-
         this.onConstructed = () => {
 
             this.bindProtoPlugins();

--- a/src/modules/emitter.js
+++ b/src/modules/emitter.js
@@ -224,7 +224,7 @@ module.exports = class Emitter extends RootEmitter {
         this.onConstructed = () => {
 
             this.bindProtoPlugins();
-            this.trigger('$.created');
+            this.trigger(['$', 'created', this.name.toLowerCase()].join('.'));
 
         };
 

--- a/src/modules/emitter.js
+++ b/src/modules/emitter.js
@@ -220,6 +220,30 @@ module.exports = class Emitter extends RootEmitter {
 
         };
 
+        this.onCreated = () => {
+            let data = {};
+            data[this.name.toLowerCase()] = this;
+            this.trigger(['$', this.name.toLowerCase(), 'created'], data);
+        };
+
+        this.onDeleted = () => {
+            let data = {};
+            data[this.name.toLowerCase()] = this;
+            this.trigger(['$', this.name.toLowerCase(), 'deleted'], data);
+        };
+
+        this.delete = () => {
+            this.emitter.removeAllListeners();
+            this.onDeleted();
+        };
+
+        this.onConstructed = () => {
+
+            this.bindProtoPlugins();
+            this.onCreated();
+
+        };
+
     }
 
 };

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -318,6 +318,46 @@ describe('remote chat list', () => {
 
 });
 
+
+let createdEventChat;
+let createdEventChat2;
+describe('join event', () => {
+
+    it('should notify chatengine on create', function join(done) {
+
+        this.timeout(4000);
+
+        ChatEngine.on('$.connected', (data) => {
+
+            assert.isObject(data.source);
+            if (data.source.channel === createdEventChat.channel) {
+                done();
+            }
+        });
+
+        createdEventChat = new ChatEngine.Chat('this-is-only-a-test');
+
+    });
+
+    it('should notify chatengine on leave', function leave(done) {
+
+        ChatEngine.once('$.disconnected', (data) => {
+            assert.isObject(data.source);
+            if (data.source.channel === createdEventChat2.channel) {
+                done();
+            }
+        });
+
+        createdEventChat2 = new ChatEngine.Chat('this-is-only-a-test-2');
+
+        createdEventChat2.on('$.connected', () => {
+            createdEventChat2.leave();
+        });
+
+    });
+
+});
+
 let myChat;
 
 let yourChat;
@@ -409,22 +449,6 @@ describe('invite', () => {
             illegalAccessChat.emit('message', 'test');
 
         });
-
-    });
-
-});
-
-
-let createdEventChat;
-describe('created event', () => {
-
-    it('should notify chatengine on create', (done) => {
-
-        ChatEngine.once('$.chat.created', (data) => {
-            done();
-        });
-
-        createdEventChat = new ChatEngine.Chat('this-is-only-a-test');
 
     });
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -97,11 +97,11 @@ describe('connect', () => {
 
         this.timeout(4000);
 
-        ChatEngine.on('$.created', (data) => {
+        ChatEngine.on('$.created', (data, source) => {
 
-            assert.isObject(data.source);
+            assert.isObject(source);
 
-            if (data.source.channel === 'global#chat#private.#this-is-only-a-test-3') {
+            if (source.channel === 'global#chat#private.#this-is-only-a-test-3') {
                 done();
             }
 
@@ -118,10 +118,10 @@ describe('connect', () => {
 
         this.timeout(4000);
 
-        ChatEngine.on('$.connected', (data) => {
+        ChatEngine.on('$.connected', (data, source) => {
 
-            assert.isObject(data.source);
-            if (data.source.channel === createdEventChat1.channel) {
+            assert.isObject(source);
+            if (source.channel === createdEventChat1.channel) {
                 done();
             }
         });
@@ -132,9 +132,9 @@ describe('connect', () => {
 
     it('should notify chatengine on disconnected', (done) => {
 
-        ChatEngine.once('$.disconnected', (data) => {
-            assert.isObject(data.source);
-            if (data.source.channel === createdEventChat2.channel) {
+        ChatEngine.once('$.disconnected', (data, source) => {
+            assert.isObject(source);
+            if (source.channel === createdEventChat2.channel) {
                 done();
             }
         });
@@ -215,166 +215,165 @@ describe('chat', () => {
 
 });
 
-// describe('history', () => {
+describe('history', () => {
 
-//     it('should get 50 messages', function get50(done) {
+    it('should get 50 messages', function get50(done) {
 
-//         let count = 0;
+        let count = 0;
 
-//         this.timeout(10000);
+        this.timeout(10000);
 
-//         let chatHistory = new ChatEngine.Chat('chat-history-2', false);
+        let chatHistory = new ChatEngine.Chat('chat-history-2', false);
 
-//         chatHistory.on('$.history.tester', (a) => {
+        chatHistory.on('$.history.tester', (a) => {
 
-//             assert.equal(a.event, 'tester');
+            assert.equal(a.event, 'tester');
 
-//             count += 1;
+            count += 1;
 
-//             if (count >= 50) {
-//                 done();
-//             }
+            if (count >= 50) {
+                done();
+            }
 
-//         });
-//         chatHistory.on('$.history.not-tester', () => {
-//             assert.isNotOk('history returning wrong events');
-//         });
+        });
+        chatHistory.on('$.history.not-tester', () => {
+            assert.isNotOk('history returning wrong events');
+        });
 
-//         let i = 0;
-//         while (i < 200) {
+        let i = 0;
+        while (i < 200) {
 
-//             chatHistory.emit('tester', {
-//                 text: 'hello world ' + i
-//             });
-//             chatHistory.emit('not-tester', {
-//                 text: 'hello world ' + i
-//             });
+            chatHistory.emit('tester', {
+                text: 'hello world ' + i
+            });
+            chatHistory.emit('not-tester', {
+                text: 'hello world ' + i
+            });
 
-//             i += 1;
+            i += 1;
 
-//         }
+        }
 
-//         chatHistory.history('tester', {
-//             max: 50,
-//             reverse: false
-//         });
+        chatHistory.history('tester', {
+            max: 50,
+            reverse: false
+        });
 
-//     });
-//     it('should get 200 messages', function get200(done) {
+    });
+    it('should get 200 messages', function get200(done) {
 
-//         let count = 0;
+        let count = 0;
 
-//         this.timeout(10000);
+        this.timeout(10000);
 
-//         let chatHistory2 = new ChatEngine.Chat('chat-history-3', false);
+        let chatHistory2 = new ChatEngine.Chat('chat-history-3', false);
 
-//         chatHistory2.on('$.history.tester', (a) => {
+        chatHistory2.on('$.history.tester', (a) => {
 
-//             assert.equal(a.event, 'tester');
+            assert.equal(a.event, 'tester');
 
-//             count += 1;
+            count += 1;
 
-//             if (count >= 200) {
-//                 done();
-//             }
+            if (count >= 200) {
+                done();
+            }
 
-//         });
+        });
 
-//         chatHistory2.on('$.history.not-tester', () => {
-//             assert.isNotOk('history returning wrong events');
-//         });
+        chatHistory2.on('$.history.not-tester', () => {
+            assert.isNotOk('history returning wrong events');
+        });
 
-//         let i = 1;
-//         while (i < 200) {
+        let i = 1;
+        while (i < 200) {
 
-//             chatHistory2.emit('tester', {
-//                 text: 'hello world ' + i
-//             });
-//             chatHistory2.emit('not-tester', {
-//                 text: 'hello world ' + i
-//             });
+            chatHistory2.emit('tester', {
+                text: 'hello world ' + i
+            });
+            chatHistory2.emit('not-tester', {
+                text: 'hello world ' + i
+            });
 
-//             i += 1;
+            i += 1;
 
-//         }
+        }
 
-//         chatHistory2.history('tester', {
-//             max: 200,
-//             reverse: false
-//         });
+        chatHistory2.history('tester', {
+            max: 200,
+            reverse: false
+        });
 
-//     });
+    });
 
-// });
+});
 
-// let ChatEngineClone;
-// let syncChat;
+let ChatEngineClone;
+let syncChat;
 
-// describe('remote chat list', () => {
+describe('remote chat list', () => {
 
-//     it('should be get notified of new chats', function getNotifiedOfNewChats(done) {
+    it('should be get notified of new chats', function getNotifiedOfNewChats(done) {
 
-//         this.timeout(10000);
+        this.timeout(10000);
 
-//         // first instance looking or new chats
-//         ChatEngine.me.once('$.session.chat.join', () => {
-//             done();
-//         });
+        // first instance looking or new chats
+        ChatEngine.me.once('$.session.chat.join', () => {
+            done();
+        });
 
-//         // create a new chat within some other instance
-//         ChatEngineClone = ChatEngineCore.create({
-//             publishKey: 'pub-c-c6303bb2-8bf8-4417-aac7-e83b52237ea6',
-//             subscribeKey: 'sub-c-67db0e7a-50be-11e7-bf50-02ee2ddab7fe',
-//         }, {
-//             endpoint: 'http://localhost:3000/insecure',
-//             globalChannel,
-//             throwErrors: false
-//         });
+        // create a new chat within some other instance
+        ChatEngineClone = ChatEngineCore.create({
+            publishKey: 'pub-c-c6303bb2-8bf8-4417-aac7-e83b52237ea6',
+            subscribeKey: 'sub-c-67db0e7a-50be-11e7-bf50-02ee2ddab7fe',
+        }, {
+            endpoint: 'http://localhost:3000/insecure',
+            globalChannel,
+            throwErrors: false
+        });
 
-//         ChatEngineClone.connect('ian', { works: true }, 'ian-authtoken');
+        ChatEngineClone.connect('ian', { works: true }, 'ian-authtoken');
 
-//         ChatEngineClone.on('$.ready', () => {
-//             syncChat = new ChatEngineClone.Chat('some channel' + new Date().getTime(), true, true);
-//         });
+        ChatEngineClone.on('$.ready', () => {
+            syncChat = new ChatEngineClone.Chat('some channel' + new Date().getTime(), true, true);
+        });
 
-//     });
+    });
 
-//     it('should keep delete in sync', function deleteSync(done) {
+    it('should keep delete in sync', function deleteSync(done) {
 
-//         this.timeout(10000);
+        this.timeout(10000);
 
-//         ChatEngine.me.once('$.session.chat.leave', () => {
+        ChatEngine.me.once('$.session.chat.leave', () => {
 
-//             setTimeout(() => {
+            setTimeout(() => {
 
-//                 assert.isUndefined(ChatEngine.chats[syncChat.channel]);
-//                 assert.isUndefined(ChatEngine.me.session.default[syncChat.channel]);
+                assert.isUndefined(ChatEngine.chats[syncChat.channel]);
+                assert.isUndefined(ChatEngine.me.session.default[syncChat.channel]);
 
-//             }, 1000);
+            }, 1000);
 
-//             done();
-//         });
+            done();
+        });
 
-//         setTimeout(() => {
+        setTimeout(() => {
 
-//             syncChat.leave();
+            syncChat.leave();
 
-//         }, 1000);
+        }, 1000);
 
 
-//     });
+    });
 
-//     it('should be populated', (done) => {
+    it('should be populated', (done) => {
 
-//         assert.isObject(ChatEngine.me.session.global);
-//         assert.isObject(ChatEngine.me.session.default);
-//         assert.isObject(ChatEngine.me.session.fixed);
-//         done();
+        assert.isObject(ChatEngine.me.session.global);
+        assert.isObject(ChatEngine.me.session.default);
+        assert.isObject(ChatEngine.me.session.fixed);
+        done();
 
-//     });
+    });
 
-// });
-
+});
 
 let myChat;
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -62,6 +62,10 @@ describe('config', () => {
             throwErrors: false
         });
 
+        ChatEngine.on('$.created.chat', (data, source) => {
+            console.log(data, source.channel)
+        });
+
         assert.isOk(ChatEngine);
 
     });
@@ -168,6 +172,8 @@ describe('chat', () => {
     });
 
     it('should get ready callback', (done) => {
+
+        this.setTimeout(5000);
 
         let chat2 = new ChatEngine.Chat('chat2');
         chat2.on('$.connected', () => {

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -416,7 +416,7 @@ describe('invite', () => {
 
 
 let createdEventChat;
-describe('created and delete', () => {
+describe('created event', () => {
 
     it('should notify chatengine on create', (done) => {
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -240,19 +240,19 @@ describe('history', () => {
             assert.isNotOk('history returning wrong events');
         });
 
-        let i = 0;
-        while (i < 200) {
+        // let i = 0;
+        // while (i < 200) {
 
-            chatHistory.emit('tester', {
-                text: 'hello world ' + i
-            });
-            chatHistory.emit('not-tester', {
-                text: 'hello world ' + i
-            });
+        //     chatHistory.emit('tester', {
+        //         text: 'hello world ' + i
+        //     });
+        //     chatHistory.emit('not-tester', {
+        //         text: 'hello world ' + i
+        //     });
 
-            i += 1;
+        //     i += 1;
 
-        }
+        // }
 
         chatHistory.history('tester', {
             max: 50,
@@ -284,19 +284,19 @@ describe('history', () => {
             assert.isNotOk('history returning wrong events');
         });
 
-        let i = 1;
-        while (i < 200) {
+        // let i = 1;
+        // while (i < 200) {
 
-            chatHistory2.emit('tester', {
-                text: 'hello world ' + i
-            });
-            chatHistory2.emit('not-tester', {
-                text: 'hello world ' + i
-            });
+        //     chatHistory2.emit('tester', {
+        //         text: 'hello world ' + i
+        //     });
+        //     chatHistory2.emit('not-tester', {
+        //         text: 'hello world ' + i
+        //     });
 
-            i += 1;
+        //     i += 1;
 
-        }
+        // }
 
         chatHistory2.history('tester', {
             max: 200,
@@ -443,7 +443,9 @@ describe('invite', () => {
 
     });
 
-    it('should not be able to join another chat', (done) => {
+    it('should not be able to join another chat', function dontJoin(done) {
+
+        this.timeout(10000);
 
         let targetChan = 'super-secret-channel-';
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -428,18 +428,4 @@ describe('created and delete', () => {
 
     });
 
-    it('should notify chatengine on delete and cleanup events', (done) => {
-
-        ChatEngine.once('$.chat.deleted', (data) => {
-            createdEventChat.emit('test');
-            done();
-        });
-
-        createdEventChat.delete();
-
-        createdEventChat.onAny(() => {
-            assert.isNotOk('should not be responding to events anymore');
-        });
-
-    });
 });

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -167,7 +167,7 @@ describe('chat', () => {
 
     });
 
-    it('should get ready callback', function getReadyCallback (done) {
+    it('should get ready callback', function getReadyCallback(done) {
 
         this.timeout(5000);
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -62,10 +62,6 @@ describe('config', () => {
             throwErrors: false
         });
 
-        ChatEngine.on('$.created.chat', (data, source) => {
-            console.log(data, source.channel)
-        });
-
         assert.isOk(ChatEngine);
 
     });
@@ -171,9 +167,9 @@ describe('chat', () => {
 
     });
 
-    it('should get ready callback', (done) => {
+    it('should get ready callback', function getReadyCallback (done) {
 
-        this.setTimeout(5000);
+        this.timeout(5000);
 
         let chat2 = new ChatEngine.Chat('chat2');
         chat2.on('$.connected', () => {

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -97,7 +97,7 @@ describe('connect', () => {
 
         this.timeout(4000);
 
-        ChatEngine.on('$.created', (data, source) => {
+        ChatEngine.on('$.created.chat', (data, source) => {
 
             assert.isObject(source);
 
@@ -180,7 +180,7 @@ describe('chat', () => {
 
     it('should get message', (done) => {
 
-        chat.on('something', (payload) => {
+        chat.once('something', (payload) => {
 
             assert.isObject(payload);
             done();

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -68,6 +68,8 @@ describe('config', () => {
 
 });
 
+let createdEventChat1;
+let createdEventChat2;
 describe('connect', () => {
 
     it('should be identified as new user', function beIdentified(done) {
@@ -86,6 +88,61 @@ describe('connect', () => {
 
         ChatEngine.on('$.network.*', (data) => {
             console.log(data.operation);
+        });
+
+    });
+
+
+    it('should notify chatengine on created', function join(done) {
+
+        this.timeout(4000);
+
+        ChatEngine.on('$.created', (data) => {
+
+            assert.isObject(data.source);
+
+            if (data.source.channel === 'global#chat#private.#this-is-only-a-test-3') {
+                done();
+            }
+
+        });
+
+        setTimeout(() => {
+            let a = new ChatEngine.Chat('this-is-only-a-test-3');
+            a.leave();
+        }, 1000);
+
+    });
+
+    it('should notify chatengine on connected', function join(done) {
+
+        this.timeout(4000);
+
+        ChatEngine.on('$.connected', (data) => {
+
+            assert.isObject(data.source);
+            if (data.source.channel === createdEventChat1.channel) {
+                done();
+            }
+        });
+
+        createdEventChat1 = new ChatEngine.Chat('this-is-only-a-test');
+
+    });
+
+    it('should notify chatengine on disconnected', (done) => {
+
+        ChatEngine.once('$.disconnected', (data) => {
+            assert.isObject(data.source);
+            if (data.source.channel === createdEventChat2.channel) {
+                done();
+            }
+        });
+
+        createdEventChat2 = new ChatEngine.Chat('this-is-only-a-test-2');
+
+        createdEventChat2.on('$.connected', () => {
+            createdEventChat2.leave();
         });
 
     });
@@ -158,205 +215,166 @@ describe('chat', () => {
 
 });
 
-describe('history', () => {
+// describe('history', () => {
 
-    it('should get 50 messages', function get50(done) {
+//     it('should get 50 messages', function get50(done) {
 
-        let count = 0;
+//         let count = 0;
 
-        this.timeout(10000);
+//         this.timeout(10000);
 
-        let chatHistory = new ChatEngine.Chat('chat-history-2', false);
+//         let chatHistory = new ChatEngine.Chat('chat-history-2', false);
 
-        chatHistory.on('$.history.tester', (a) => {
+//         chatHistory.on('$.history.tester', (a) => {
 
-            assert.equal(a.event, 'tester');
+//             assert.equal(a.event, 'tester');
 
-            count += 1;
+//             count += 1;
 
-            if (count >= 50) {
-                done();
-            }
+//             if (count >= 50) {
+//                 done();
+//             }
 
-        });
-        chatHistory.on('$.history.not-tester', () => {
-            assert.isNotOk('history returning wrong events');
-        });
+//         });
+//         chatHistory.on('$.history.not-tester', () => {
+//             assert.isNotOk('history returning wrong events');
+//         });
 
-        let i = 0;
-        while (i < 200) {
+//         let i = 0;
+//         while (i < 200) {
 
-            chatHistory.emit('tester', {
-                text: 'hello world ' + i
-            });
-            chatHistory.emit('not-tester', {
-                text: 'hello world ' + i
-            });
+//             chatHistory.emit('tester', {
+//                 text: 'hello world ' + i
+//             });
+//             chatHistory.emit('not-tester', {
+//                 text: 'hello world ' + i
+//             });
 
-            i += 1;
+//             i += 1;
 
-        }
+//         }
 
-        chatHistory.history('tester', {
-            max: 50,
-            reverse: false
-        });
+//         chatHistory.history('tester', {
+//             max: 50,
+//             reverse: false
+//         });
 
-    });
-    it('should get 200 messages', function get200(done) {
+//     });
+//     it('should get 200 messages', function get200(done) {
 
-        let count = 0;
+//         let count = 0;
 
-        this.timeout(10000);
+//         this.timeout(10000);
 
-        let chatHistory2 = new ChatEngine.Chat('chat-history-3', false);
+//         let chatHistory2 = new ChatEngine.Chat('chat-history-3', false);
 
-        chatHistory2.on('$.history.tester', (a) => {
+//         chatHistory2.on('$.history.tester', (a) => {
 
-            assert.equal(a.event, 'tester');
+//             assert.equal(a.event, 'tester');
 
-            count += 1;
+//             count += 1;
 
-            if (count >= 200) {
-                done();
-            }
+//             if (count >= 200) {
+//                 done();
+//             }
 
-        });
+//         });
 
-        chatHistory2.on('$.history.not-tester', () => {
-            assert.isNotOk('history returning wrong events');
-        });
+//         chatHistory2.on('$.history.not-tester', () => {
+//             assert.isNotOk('history returning wrong events');
+//         });
 
-        let i = 1;
-        while (i < 200) {
+//         let i = 1;
+//         while (i < 200) {
 
-            chatHistory2.emit('tester', {
-                text: 'hello world ' + i
-            });
-            chatHistory2.emit('not-tester', {
-                text: 'hello world ' + i
-            });
+//             chatHistory2.emit('tester', {
+//                 text: 'hello world ' + i
+//             });
+//             chatHistory2.emit('not-tester', {
+//                 text: 'hello world ' + i
+//             });
 
-            i += 1;
+//             i += 1;
 
-        }
+//         }
 
-        chatHistory2.history('tester', {
-            max: 200,
-            reverse: false
-        });
+//         chatHistory2.history('tester', {
+//             max: 200,
+//             reverse: false
+//         });
 
-    });
+//     });
 
-});
+// });
 
-let ChatEngineClone;
-let syncChat;
+// let ChatEngineClone;
+// let syncChat;
 
-describe('remote chat list', () => {
+// describe('remote chat list', () => {
 
-    it('should be get notified of new chats', function getNotifiedOfNewChats(done) {
+//     it('should be get notified of new chats', function getNotifiedOfNewChats(done) {
 
-        this.timeout(10000);
+//         this.timeout(10000);
 
-        // first instance looking or new chats
-        ChatEngine.me.once('$.session.chat.join', () => {
-            done();
-        });
+//         // first instance looking or new chats
+//         ChatEngine.me.once('$.session.chat.join', () => {
+//             done();
+//         });
 
-        // create a new chat within some other instance
-        ChatEngineClone = ChatEngineCore.create({
-            publishKey: 'pub-c-c6303bb2-8bf8-4417-aac7-e83b52237ea6',
-            subscribeKey: 'sub-c-67db0e7a-50be-11e7-bf50-02ee2ddab7fe',
-        }, {
-            endpoint: 'http://localhost:3000/insecure',
-            globalChannel,
-            throwErrors: false
-        });
+//         // create a new chat within some other instance
+//         ChatEngineClone = ChatEngineCore.create({
+//             publishKey: 'pub-c-c6303bb2-8bf8-4417-aac7-e83b52237ea6',
+//             subscribeKey: 'sub-c-67db0e7a-50be-11e7-bf50-02ee2ddab7fe',
+//         }, {
+//             endpoint: 'http://localhost:3000/insecure',
+//             globalChannel,
+//             throwErrors: false
+//         });
 
-        ChatEngineClone.connect('ian', { works: true }, 'ian-authtoken');
+//         ChatEngineClone.connect('ian', { works: true }, 'ian-authtoken');
 
-        ChatEngineClone.on('$.ready', () => {
-            syncChat = new ChatEngineClone.Chat('some channel' + new Date().getTime(), true, true);
-        });
+//         ChatEngineClone.on('$.ready', () => {
+//             syncChat = new ChatEngineClone.Chat('some channel' + new Date().getTime(), true, true);
+//         });
 
-    });
+//     });
 
-    it('should keep delete in sync', function deleteSync(done) {
+//     it('should keep delete in sync', function deleteSync(done) {
 
-        this.timeout(10000);
+//         this.timeout(10000);
 
-        ChatEngine.me.once('$.session.chat.leave', () => {
+//         ChatEngine.me.once('$.session.chat.leave', () => {
 
-            setTimeout(() => {
+//             setTimeout(() => {
 
-                assert.isUndefined(ChatEngine.chats[syncChat.channel]);
-                assert.isUndefined(ChatEngine.me.session.default[syncChat.channel]);
+//                 assert.isUndefined(ChatEngine.chats[syncChat.channel]);
+//                 assert.isUndefined(ChatEngine.me.session.default[syncChat.channel]);
 
-            }, 1000);
+//             }, 1000);
 
-            done();
-        });
+//             done();
+//         });
 
-        setTimeout(() => {
+//         setTimeout(() => {
 
-            syncChat.leave();
+//             syncChat.leave();
 
-        }, 1000);
+//         }, 1000);
 
 
-    });
+//     });
 
-    it('should be populated', (done) => {
+//     it('should be populated', (done) => {
 
-        assert.isObject(ChatEngine.me.session.global);
-        assert.isObject(ChatEngine.me.session.default);
-        assert.isObject(ChatEngine.me.session.fixed);
-        done();
+//         assert.isObject(ChatEngine.me.session.global);
+//         assert.isObject(ChatEngine.me.session.default);
+//         assert.isObject(ChatEngine.me.session.fixed);
+//         done();
 
-    });
+//     });
 
-});
+// });
 
-
-let createdEventChat;
-let createdEventChat2;
-describe('join event', () => {
-
-    it('should notify chatengine on create', function join(done) {
-
-        this.timeout(4000);
-
-        ChatEngine.on('$.connected', (data) => {
-
-            assert.isObject(data.source);
-            if (data.source.channel === createdEventChat.channel) {
-                done();
-            }
-        });
-
-        createdEventChat = new ChatEngine.Chat('this-is-only-a-test');
-
-    });
-
-    it('should notify chatengine on leave', function leave(done) {
-
-        ChatEngine.once('$.disconnected', (data) => {
-            assert.isObject(data.source);
-            if (data.source.channel === createdEventChat2.channel) {
-                done();
-            }
-        });
-
-        createdEventChat2 = new ChatEngine.Chat('this-is-only-a-test-2');
-
-        createdEventChat2.on('$.connected', () => {
-            createdEventChat2.leave();
-        });
-
-    });
-
-});
 
 let myChat;
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -413,3 +413,33 @@ describe('invite', () => {
     });
 
 });
+
+
+let createdEventChat;
+describe('created and delete', () => {
+
+    it('should notify chatengine on create', (done) => {
+
+        ChatEngine.once('$.chat.created', (data) => {
+            done();
+        });
+
+        createdEventChat = new ChatEngine.Chat('this-is-only-a-test');
+
+    });
+
+    it('should notify chatengine on delete and cleanup events', (done) => {
+
+        ChatEngine.once('$.chat.deleted', (data) => {
+            createdEventChat.emit('test');
+            done();
+        });
+
+        createdEventChat.delete();
+
+        createdEventChat.onAny(() => {
+            assert.isNotOk('should not be responding to events anymore');
+        });
+
+    });
+});

--- a/test/unit/bootstrap.test.js
+++ b/test/unit/bootstrap.test.js
@@ -43,6 +43,7 @@ describe('#bootstrap', () => {
     });
 
     it('connect', (done) => {
+
         chatEngineInstance.on('$.ready', (data) => {
             assert(data.me.uuid === 'user1', 'was assigned uuid to me');
             done();


### PR DESCRIPTION
All objects now call ```onCreated``` which fires an event like ```$.created.x```.

Events emitted to the ChatEngine object now supply the object that emitted them as the second parameter to ```on```.

@parfeon, you can now be notified of all chats created with:

```js
ChatEngine.on('$.created.chat', (data, source) => {
        console.log('this was emitted by the chat', source);
});
```

You can also get notified of all chats connected like:

```js
ChatEngine.on('$.connected', (data, source) => {
        console.log('chat was connected', source);
});
```

You can also get notified of all chats left like:

```js
ChatEngine.on('$.connected', (data, source) => {
        console.log('chat was disconnected', source);
});
```