### PR TITLE
Add ability to sync arbitrary metadata in chats

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -110,7 +110,7 @@ module.exports = (ceConfig, pnConfig) => {
 
             // create a new chat to use as global chat
             // we don't do auth on this one because it's assumed to be done with the /auth request below
-            ChatEngine.global = new Chat(ChatEngine, ceConfig.globalChannel, false, true, 'global');
+            ChatEngine.global = new Chat(ChatEngine, ceConfig.globalChannel, false, true, null, 'global');
 
             // create a new user that represents this client
             ChatEngine.me = new Me(ChatEngine, pnConfig.uuid, authData);

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -19,7 +19,7 @@ const User = require('../components/user');
  */
 module.exports = class Chat extends Emitter {
 
-    constructor(chatEngine, channel = new Date().getTime(), needGrant = true, autoConnect = true, group = 'default') {
+    constructor(chatEngine, channel = new Date().getTime(), needGrant = true, autoConnect = true, group = 'default', meta = {}) {
 
         super(chatEngine);
 
@@ -60,6 +60,8 @@ module.exports = class Chat extends Emitter {
         * @readonly
         */
         this.group = group;
+
+        this.meta = meta;
 
         /**
          A list of users in this {@link Chat}. Automatically kept in sync as users join and leave the chat.
@@ -239,7 +241,8 @@ module.exports = class Chat extends Emitter {
             return {
                 channel: this.channel,
                 group: this.group,
-                private: this.isPrivate
+                private: this.isPrivate,
+                meta: this.meta
             };
 
         };

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -19,7 +19,7 @@ const User = require('../components/user');
  */
 module.exports = class Chat extends Emitter {
 
-    constructor(chatEngine, channel = new Date().getTime(), needGrant = true, autoConnect = true, group = 'default', meta = {}) {
+    constructor(chatEngine, channel = new Date().getTime(), needGrant = true, autoConnect = true, meta = {}, group = 'default') {
 
         super(chatEngine);
 

--- a/src/components/me.js
+++ b/src/components/me.js
@@ -86,7 +86,7 @@ module.exports = class Me extends User {
             this.session[chat.group][chat.channel] = existingChat;
         } else {
             // otherwise, try to recreate it with the server information
-            this.session[chat.group][chat.channel] = new Chat(this.chatEngine, chat.channel, chat.private, false, chat.group, chat.meta);
+            this.session[chat.group][chat.channel] = new Chat(this.chatEngine, chat.channel, chat.private, false, chat.meta, chat.group);
 
             /**
             * Fired when another identical instance of {@link ChatEngine} and {@link Me} joins a {@link Chat} that this instance of {@link ChatEngine} is unaware of.

--- a/src/components/me.js
+++ b/src/components/me.js
@@ -86,7 +86,7 @@ module.exports = class Me extends User {
             this.session[chat.group][chat.channel] = existingChat;
         } else {
             // otherwise, try to recreate it with the server information
-            this.session[chat.group][chat.channel] = new Chat(this.chatEngine, chat.channel, chat.private, false, chat.group);
+            this.session[chat.group][chat.channel] = new Chat(this.chatEngine, chat.channel, chat.private, false, chat.group, chat.meta);
 
             /**
             * Fired when another identical instance of {@link ChatEngine} and {@link Me} joins a {@link Chat} that this instance of {@link ChatEngine} is unaware of.

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -59,7 +59,7 @@ module.exports = class User extends Emitter {
          */
 
         // grants for these chats are done on auth. Even though they're marked private, they are locked down via the server
-        this.feed = new Chat(chatEngine, [chatEngine.global.channel, 'user', uuid, 'read.', 'feed'].join('#'), false, this.constructor.name === 'Me', 'feed');
+        this.feed = new Chat(chatEngine, [chatEngine.global.channel, 'user', uuid, 'read.', 'feed'].join('#'), false, this.constructor.name === 'Me', null, 'feed');
 
         /**
          * Direct is a private channel that anybody can publish to but only
@@ -80,7 +80,7 @@ module.exports = class User extends Emitter {
          * them.direct.connect();
          * them.direct.emit('private-message', {secret: 42});
          */
-        this.direct = new Chat(chatEngine, [chatEngine.global.channel, 'user', uuid, 'write.', 'direct'].join('#'), false, this.constructor.name === 'Me', 'direct');
+        this.direct = new Chat(chatEngine, [chatEngine.global.channel, 'user', uuid, 'write.', 'direct'].join('#'), false, this.constructor.name === 'Me', null, 'direct');
 
         // if the user does not exist at all and we get enough
         // information to build the user

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -260,7 +260,9 @@ describe('remote chat list', () => {
         this.timeout(10000);
 
         // first instance looking or new chats
-        ChatEngine.me.once('$.session.chat.join', () => {
+        ChatEngine.me.once('$.session.chat.join', (data) => {
+            console.log(data)
+            assert.equal(data.chat.meta.works, true);
             done();
         });
 
@@ -277,7 +279,7 @@ describe('remote chat list', () => {
         ChatEngineClone.connect('ian', { works: true }, 'ian-authtoken');
 
         ChatEngineClone.on('$.ready', () => {
-            syncChat = new ChatEngineClone.Chat('some channel' + new Date().getTime(), true, true);
+            syncChat = new ChatEngineClone.Chat('some channel' + new Date().getTime(), true, true, null, {works: true});
         });
 
     });

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -279,7 +279,7 @@ describe('remote chat list', () => {
         ChatEngineClone.connect('ian', { works: true }, 'ian-authtoken');
 
         ChatEngineClone.on('$.ready', () => {
-            syncChat = new ChatEngineClone.Chat('some channel' + new Date().getTime(), true, true, null, {works: true});
+            syncChat = new ChatEngineClone.Chat('some channel' + new Date().getTime(), true, true, { works: true });
         });
 
     });

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -261,7 +261,6 @@ describe('remote chat list', () => {
 
         // first instance looking or new chats
         ChatEngine.me.once('$.session.chat.join', (data) => {
-            console.log(data)
             assert.equal(data.chat.meta.works, true);
             done();
         });
@@ -363,7 +362,11 @@ describe('invite', () => {
             myChat = new ChatEngine.Chat(payload.data.channel);
 
             myChat.on('$.connected', () => {
-                done();
+
+                myChat.emit('message', {
+                    text: 'sup?'
+                });
+
             });
 
         });
@@ -371,22 +374,13 @@ describe('invite', () => {
         // me is the current context
         yourChat.invite(me);
 
-    });
-
-    it('two users are able to talk to each other in private channel', function twoUsersTalk(done) {
-
-        this.timeout(5000);
-
         yourChat.on('message', (payload) => {
             assert.equal(payload.data.text, 'sup?');
             done();
         });
 
-        myChat.emit('message', {
-            text: 'sup?'
-        });
-
     });
+
 
     it('should not be able to join another chat', (done) => {
 


### PR DESCRIPTION
A couple developers have requested the ability to add metadata to chats (to name them for example).

A few weeks ago I updated server.js to support arbitrary metadata in chats. This pull simply adds a new parameter to ```new Chat``` that allows you to specify a JSON object that will be synced between clients.

There is currently no ability to update the state once it's been set. 