### PR TITLE
meta field access otb on pn msg in chat engine

### DIFF
--- a/src/components/event.js
+++ b/src/components/event.js
@@ -57,9 +57,13 @@ class Event {
 
         m.event = this.event;
 
+        let meta = m.data.meta;
+        delete m.data.meta;
+
         this.chatEngine.pubnub.publish({
             message: m,
-            channel: this.channel
+            channel: this.channel,
+            meta: meta
         }, (status) => {
 
             if (status.statusCode === 200) {


### PR DESCRIPTION
Allow a developer to add properties to the meta object on a pubnub request. this can be used for auth tokens.