### PR TITLE
Refactor connect functionality

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -389,31 +389,18 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
             });
         };
 
-        async.parallel([
-            (next) => {
-                ChatEngine.request('post', 'bootstrap').then(() => {
-                    next(null);
-                }).catch(next);
-            },
-            (next) => {
-                ChatEngine.request('post', 'user_read').then(() => {
-                    next(null);
-                }).catch(next);
-            },
-            (next) => {
-                ChatEngine.request('post', 'user_write').then(() => {
-                    next(null);
-                }).catch(next);
-            },
-            (next) => {
-                ChatEngine.request('post', 'group').then(complete).catch(next);
-            }
-        ], (error) => {
-            if (error) {
-                ChatEngine.throwError(ChatEngine, '_emit', 'auth', new Error('There was a problem logging into the auth server (' + ceConfig.endpoint + ').'), { error });
-            }
-        });
+        const tasks = [
+            ChatEngine.request.bind(ChatEngine, 'post', 'bootstrap'),
+            ChatEngine.request.bind(ChatEngine, 'post', 'user_read'),
+            ChatEngine.request.bind('post', 'user_write'),
+            ChatEngine.request.bind('post', 'group').then(complete)
+        ];
 
+        return Promise
+            .all(tasks)
+            .catch((error) => {
+                ChatEngine.throwError(ChatEngine, '_emit', 'auth', new Error('There was a problem logging into the auth server (' + ceConfig.endpoint + ').'), { error });
+            });
     };
 
     /**

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -392,12 +392,13 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
         const tasks = [
             ChatEngine.request.bind(ChatEngine, 'post', 'bootstrap'),
             ChatEngine.request.bind(ChatEngine, 'post', 'user_read'),
-            ChatEngine.request.bind('post', 'user_write'),
-            ChatEngine.request.bind('post', 'group').then(complete)
+            ChatEngine.request.bind(ChatEngine, 'post', 'user_write'),
+            ChatEngine.request.bind(ChatEngine, 'post', 'group')
         ];
 
         return Promise
             .all(tasks)
+            .then(() => complete())
             .catch((error) => {
                 ChatEngine.throwError(ChatEngine, '_emit', 'auth', new Error('There was a problem logging into the auth server (' + ceConfig.endpoint + ').'), { error });
             });


### PR DESCRIPTION
This pull request promises 2 things:

- Add editorconfig (for people who don't know Pubnub employee uses 4 chars as default editor config)
- Use Promise.all() instead of async.parallel() to handle connect event and return promise on connect to catch errors.

The main reason for opening this PR is that I couldn't find any way to catch the error inside connect.

- Try catch doesn't work because connect event does async stuff and the upper scope doesn't know it.