### PR TITLE
Isolate tests for Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "body-parser": "^1.17.2",
     "chai": "^3.5.0",
     "chat-engine-typing-indicator": "0.0.x",
+    "decache": "^4.3.0",
     "docdash": "^0.4.0",
     "es6-promise": "^4.1.1",
     "eslint": "^4.7.1",

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -394,7 +394,9 @@ describe('remote chat list', () => {
 
         });
 
-        let newChatToNotify = new ChatEngineClone.Chat(newChannel);
+        setTimeout(() => {
+            let newChatToNotify = new ChatEngineClone.Chat(newChannel);
+        }, 5000);
 
     });
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -1,5 +1,5 @@
-const ChatEngineCore = require('../../src/index.js');
 const assert = require('chai').assert;
+let decache = require('decache');
 
 const pubkey = 'pub-c-fab5d74d-8118-444c-b652-4a8ee0beee92';
 const subkey = 'sub-c-696d9116-c668-11e7-afd4-56ea5891403c';
@@ -8,16 +8,37 @@ let ChatEngine;
 let ChatEngineYou;
 let ChatEngineClone;
 let ChatEngineSync;
-let globalChannel = 'global';
+let ChatEngineHistory;
 
-let username = 'ian' + new Date().getTime();
-let yousername = 'stephen' + new Date().getTime();
+let globalChannel;
+let username;
+let yousername;
+
+let iterations = 0;
+
+let version = process.version.replace(/\./g, '-');
+
+function reset(done) {
+
+    this.timeout(60000);
+
+    globalChannel = ['test', version, iterations].join('-');
+    username = ['ian', version, iterations].join('-');
+    yousername = ['stephen', version, iterations].join('-');
+
+    iterations++;
+
+    decache('../../src/index.js');
+
+    done();
+
+}
 
 function createChatEngine(done) {
 
-    this.timeout(15000);
+    this.timeout(60000);
 
-    ChatEngine = ChatEngineCore.create({
+    ChatEngine = require('../../src/index.js').create({
         publishKey: pubkey,
         subscribeKey: subkey
     }, {
@@ -25,17 +46,14 @@ function createChatEngine(done) {
         throwErrors: true
     });
     ChatEngine.connect(username, { works: true }, username);
-    ChatEngine.on('$.ready', () => {
-        done();
-    });
+    ChatEngine.on('$.ready', () => done());
 
 }
 
 function createChatEngineSync(done) {
 
-    this.timeout(15000);
-
-    ChatEngineSync = ChatEngineCore.create({
+    this.timeout(60000);
+    ChatEngineSync = require('../../src/index.js').create({
         publishKey: pubkey,
         subscribeKey: subkey
     }, {
@@ -45,18 +63,16 @@ function createChatEngineSync(done) {
     });
 
     ChatEngineSync.connect(username, { works: false }, username);
-    ChatEngineSync.on('$.ready', () => {
-        done();
-    });
+    ChatEngineSync.on('$.ready', () => done());
 
 }
 
 
 function createChatEngineClone(done) {
 
-    this.timeout(15000);
+    this.timeout(60000);
 
-    ChatEngineClone = ChatEngineCore.create({
+    ChatEngineClone = require('../../src/index.js').create({
         publishKey: pubkey,
         subscribeKey: subkey
     }, {
@@ -64,18 +80,17 @@ function createChatEngineClone(done) {
         enableSync: true,
         throwErrors: true
     });
+
     ChatEngineClone.connect(username, { works: true }, username);
-    ChatEngineClone.on('$.ready', () => {
-        done();
-    });
+    ChatEngineClone.on('$.ready', () => done());
 
 }
 
 function createChatEngineYou(done) {
 
-    this.timeout(15000);
+    this.timeout(60000);
 
-    ChatEngineYou = ChatEngineCore.create({
+    ChatEngineYou = require('../../src/index.js').create({
         publishKey: pubkey,
         subscribeKey: subkey
     }, {
@@ -84,28 +99,25 @@ function createChatEngineYou(done) {
         enableSync: false
     });
     ChatEngineYou.connect(yousername, { works: true }, yousername);
-    ChatEngineYou.on('$.ready', () => {
-        done();
-    });
+    ChatEngineYou.on('$.ready', () => done());
 
 }
 
-function reset() {
+function createChatEngineHistory(done) {
 
-    ChatEngine = false;
-    ChatEngineYou = false;
-    ChatEngineClone = false;
-    ChatEngineSync = false;
+    this.timeout(60000);
+
+    ChatEngineHistory = require('../../src/index.js').create({
+        publishKey: pubkey,
+        subscribeKey: subkey
+    }, {
+        globalChannel: 'global',
+        throwErrors: true
+    });
+    ChatEngineHistory.connect(yousername, { works: true }, yousername);
+    ChatEngineHistory.on('$.ready', () => done());
 
 }
-
-describe('import', () => {
-
-    it('ChatEngine should be imported', () => {
-        assert.isObject(ChatEngineCore, 'was successfully created');
-    });
-
-});
 
 let examplePlugin = () => {
 
@@ -141,28 +153,19 @@ let examplePlugin = () => {
 
 };
 
-let createdEventChat1;
-let createdEventChat2;
 describe('connect', () => {
 
+    beforeEach(reset);
     beforeEach(createChatEngine);
-    afterEach(reset);
 
     it('should be identified as new user', function beIdentified() {
-
-        this.timeout(16000);
-
+        this.timeout(60000);
         assert.isObject(ChatEngine.me);
-
-        ChatEngine.on('$.network.*', (data) => {
-            console.log(data.operation);
-        });
-
     });
 
     it('should notify chatengine on created', function join(done) {
 
-        this.timeout(6000);
+        this.timeout(60000);
 
         let newChat = 'this-is-only-a-test-3' + new Date().getTime();
         let a = false;
@@ -179,15 +182,16 @@ describe('connect', () => {
 
         a = new ChatEngine.Chat(newChat);
 
-        setTimeout(() => {
-            a.leave();
-        }, 1000);
+        a.on('$.connected', () => {
+            setTimeout(() => a.leave(), 1000);
+        });
 
     });
 
     it('should notify chatengine on connected', function join(done) {
 
-        this.timeout(10000);
+        this.timeout(60000);
+        let createdEventChat1;
 
         ChatEngine.on('$.connected', (data, source) => {
 
@@ -197,13 +201,14 @@ describe('connect', () => {
             }
         });
 
-        createdEventChat1 = new ChatEngine.Chat('this-is-only-a-test' + new Date());
+        createdEventChat1 = new ChatEngine.Chat('this-is-only-a-test' + new Date().getTime());
 
     });
 
     it('should notify chatengine on disconnected', function disconnected(done) {
 
-        this.timeout(4000);
+        this.timeout(60000);
+        let createdEventChat2;
 
         ChatEngine.on('$.disconnected', (data, source) => {
 
@@ -214,28 +219,24 @@ describe('connect', () => {
             }
         });
 
-        createdEventChat2 = new ChatEngine.Chat('this-is-only-a-test-2' + new Date());
+        createdEventChat2 = new ChatEngine.Chat('this-is-only-a-test-2' + new Date().getTime());
 
-        createdEventChat2.on('$.connected', () => {
-            createdEventChat2.leave();
-        });
+        createdEventChat2.on('$.connected', () => createdEventChat2.leave());
 
     });
 
 });
 
-let chat;
-
 describe('chat', () => {
 
+    beforeEach(reset);
     beforeEach(createChatEngine);
-    afterEach(reset);
 
     it('should get me as join event', function getMe(done) {
 
-        this.timeout(10000);
+        this.timeout(60000);
 
-        chat = new ChatEngine.Chat('chat-teser' + new Date().getTime());
+        let chat = new ChatEngine.Chat('chat-teser' + new Date().getTime());
 
         chat.on('$.online.*', (p) => {
 
@@ -248,27 +249,21 @@ describe('chat', () => {
     });
 
     it('should get connected callback', function getReadyCallback(done) {
-
-        this.timeout(5000);
+        this.timeout(60000);
 
         let chat2 = new ChatEngine.Chat('chat2' + new Date().getTime());
-        chat2.on('$.connected', () => {
-
-            done();
-
-        });
-
+        chat2.on('$.connected', () => done());
     });
 
     it('should get message', function shouldGetMessage(done) {
 
-        this.timeout(12000);
+        this.timeout(60000);
+
+        let chat = new ChatEngine.Chat('chat-teser3' + new Date().getTime());
 
         chat.once('something', (payload) => {
-
             assert.isObject(payload);
             done();
-
         });
 
         setTimeout(() => {
@@ -281,6 +276,7 @@ describe('chat', () => {
 
     it('should bind a plugin', () => {
 
+        let chat = new ChatEngine.Chat('chat-teser' + new Date().getTime());
         chat.plugin(examplePlugin());
 
         assert(chat.constructWorks, 'bound to construct');
@@ -292,7 +288,7 @@ describe('chat', () => {
 
         ChatEngine.proto('Chat', examplePlugin());
 
-        let newChat = new ChatEngine.Chat('some-other-chat');
+        let newChat = new ChatEngine.Chat('some-other-chat' + new Date().getTime());
 
         assert(newChat.constructWorks, 'bound to construct');
         assert(newChat.testPlugin.newMethod(), 'new method added');
@@ -301,39 +297,30 @@ describe('chat', () => {
 
 });
 
-let chatHistory;
 describe('history', () => {
 
-    beforeEach(createChatEngine);
-    afterEach(reset);
+    beforeEach(reset);
+    beforeEach(createChatEngineHistory);
 
     it('should get 50 messages', function get50(done) {
 
+        this.timeout(60000);
         let count = 0;
 
-        this.timeout(30000);
-
-        chatHistory = new ChatEngine.Chat('chat-history', false);
+        let chatHistory = new ChatEngineHistory.Chat('chat-history');
 
         chatHistory.on('$.connected', () => {
 
-            setTimeout(() => {
-
-                chatHistory.search({
-                    event: 'tester',
-                    limit: 50
-                }).on('tester', (a) => {
-
-                    assert.equal(a.event, 'tester');
-
-                    count += 1;
-
-                }).on('$.search.finish', () => {
-                    assert.equal(count, 50, 'correct # of results');
-                    done();
-                });
-
-            }, 5000);
+            chatHistory.search({
+                event: 'tester',
+                limit: 50
+            }).on('tester', (a) => {
+                assert.equal(a.event, 'tester');
+                count += 1;
+            }).on('$.search.finish', () => {
+                assert.equal(count, 50, 'correct # of results');
+                done();
+            });
 
         });
 
@@ -344,27 +331,22 @@ describe('history', () => {
         let count = 0;
 
         this.timeout(60000);
-
-        let chatHistory2 = new ChatEngine.Chat('chat-history', false);
+        let chatHistory2 = new ChatEngineHistory.Chat('chat-history');
 
         chatHistory2.on('$.connected', () => {
 
-            setTimeout(() => {
+            chatHistory2.search({
+                event: 'tester',
+                limit: 200
+            }).on('tester', (a) => {
 
-                chatHistory2.search({
-                    event: 'tester',
-                    limit: 200
-                }).on('tester', (a) => {
+                assert.equal(a.event, 'tester');
+                count += 1;
 
-                    assert.equal(a.event, 'tester');
-                    count += 1;
-
-                }).on('$.search.finish', () => {
-                    assert.equal(count, 200, 'correct # of results');
-                    done();
-                });
-
-            }, 5000);
+            }).on('$.search.finish', () => {
+                assert.equal(count, 200, 'correct # of results');
+                done();
+            });
 
         });
 
@@ -372,36 +354,36 @@ describe('history', () => {
 
     it('should get messages without event', function get50(done) {
 
-        this.timeout(30000);
+        this.timeout(60000);
 
-        chatHistory.search({
-            limit: 10
-        }).on('tester', (a) => {
+        let chatHistory = new ChatEngineHistory.Chat('chat-history-8');
 
-            assert.equal(a.event, 'tester');
+        chatHistory.on('$.connected', () => {
 
-        }).on('$.search.finish', () => {
-            done();
+            chatHistory.search({
+                limit: 10
+            }).on('tester', (a) => {
+
+                assert.equal(a.event, 'tester');
+
+            }).on('$.search.finish', () => done());
+
         });
 
     });
 
 });
 
-let syncChat;
-
-let newChannel = 'sync-chat' + new Date().getTime();
-let newChannel2 = 'sync-chat2' + new Date().getTime();
-
 describe('remote chat list', () => {
 
+    beforeEach(reset);
     beforeEach(createChatEngineClone);
     beforeEach(createChatEngineSync);
-    afterEach(reset);
 
     it('should be get notified of new chats', function getNotifiedOfNewChats(done) {
 
         this.timeout(60000);
+        let newChannel = 'sync-chat' + new Date().getTime();
 
         // first instance looking or new chats
         ChatEngineSync.me.on('$.session.chat.join', (payload) => {
@@ -412,13 +394,13 @@ describe('remote chat list', () => {
 
         });
 
-        syncChat = new ChatEngineClone.Chat(newChannel);
+        let newChatToNotify = new ChatEngineClone.Chat(newChannel);
 
     });
 
     it('should be populated', function shouldBePopulated(done) {
 
-        this.timeout(20000);
+        this.timeout(60000);
 
         ChatEngineSync.me.once('$.session.group.restored', (payload) => {
 
@@ -434,6 +416,9 @@ describe('remote chat list', () => {
 
         this.timeout(60000);
 
+        let newChannel2 = 'sync-chat2' + new Date().getTime();
+        let syncChat;
+
         ChatEngineSync.me.on('$.session.chat.leave', (payload) => {
 
             if (payload.chat.channel.indexOf(newChannel2) > -1) {
@@ -442,48 +427,41 @@ describe('remote chat list', () => {
 
         });
 
-        // first instance looking or new chats
-        ChatEngineSync.me.once('$.session.chat.join', () => {
-
-            syncChat.leave();
-
-        });
-
+        ChatEngineSync.me.once('$.session.chat.join', () => syncChat.leave());
         syncChat = new ChatEngineClone.Chat(newChannel2);
 
     });
 
 });
 
-let myChat;
-
-let yourChat;
-
-let privChannel = 'secret-channel-' + new Date().getTime();
-
 describe('invite', () => {
 
+    beforeEach(reset);
     beforeEach(createChatEngine);
     beforeEach(createChatEngineYou);
-    afterEach(reset);
 
     it('two users are able to talk to each other in private channel', function shouldInvite(done) {
 
         this.timeout(60000);
 
-        yourChat = new ChatEngineYou.Chat(privChannel);
+        let myChat;
+        let yourChat;
+        let privChannel = 'predictable-secret-channel';
 
-        yourChat.on('$.connected', () => {
+        yourChat = new ChatEngineYou.Chat(privChannel, true);
+        yourChat.on('$.connected', () => yourChat.invite(ChatEngine.me));
 
-            // me is the current context
-            yourChat.invite(ChatEngine.me);
-
-        });
+        let done2 = false;
 
         yourChat.on('message', (payload) => {
 
-            assert.equal(payload.data.text, 'sup?');
-            done();
+            if (!done2) {
+
+                assert.equal(payload.data.text, 'sup?');
+                done();
+                done2 = true;
+
+            }
 
         });
 
@@ -493,13 +471,9 @@ describe('invite', () => {
 
             myChat.on('$.connected', () => {
 
-                setTimeout(() => {
-
-                    myChat.emit('message', {
-                        text: 'sup?'
-                    });
-
-                }, 5000);
+                myChat.emit('message', {
+                    text: 'sup?'
+                });
 
             });
 

--- a/test/unit/bootstrap.test.js
+++ b/test/unit/bootstrap.test.js
@@ -41,7 +41,9 @@ describe('#bootstrap', () => {
         done();
     });
 
-    it('connect', (done) => {
+    it('connect', function itConnect(done) {
+
+        this.timeout(20000);
 
         chatEngineInstance.on('$.ready', (data) => {
             assert(data.me.uuid === 'user1', 'was assigned uuid to me');


### PR DESCRIPTION
This pull isolates tests by:

- Clearing the npm cache between tests
- Isolating tests based on Node Version (for when Travis runs tests in parallel)
- Using a new global channel for every test
