### PR TITLE
Update users in memory before events are fired, implement .leave() properly

### DIFF
--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -436,7 +436,7 @@ class Chat extends Emitter {
     }
 
     /**
-     * Fired upon successful connection to the network through any means..
+     * Fired upon successful connection to the network.
      * @private
      */
     onConnected() {

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -457,8 +457,8 @@ class Chat extends Emitter {
      * @private
      */
     onLeave() {
-        this.connected = false;
         this.trigger('$.left');
+        this.onDisconnected();
     }
 
     /**

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -453,7 +453,7 @@ class Chat extends Emitter {
         this.trigger('$.disconnected');
     }
     /**
-     * Fires upon disconnection from the network through any means.
+     * Fires upon manually invoked leaving.
      * @private
      */
     onLeave() {
@@ -482,6 +482,7 @@ class Chat extends Emitter {
                 // trigger the disconnect events and update state
                 this.onLeave();
 
+                // tell the chat we've left
                 this.emit('$.system.leave', { subject: this.objectify() });
 
                 // tell session we've left
@@ -555,8 +556,8 @@ class Chat extends Emitter {
              * @param {Object} data.user The {@link User} that disconnected
              * @example
              * chat.on('$.offline.disconnect', (data) => {
-                      *     console.log('User disconnected from the network:', data.user);
-                      * });
+             *     console.log('User disconnected from the network:', data.user);
+             * });
              */
             this.trigger('$.offline.disconnect', { user });
 

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -452,6 +452,14 @@ class Chat extends Emitter {
         this.connected = false;
         this.trigger('$.disconnected');
     }
+    /**
+     * Fires upon disconnection from the network through any means.
+     * @private
+     */
+    onLeave() {
+        this.connected = false;
+        this.trigger('$.left');
+    }
 
     /**
      * Leave from the {@link Chat} on behalf of {@link Me}. Disconnects from the {@link Chat} and will stop
@@ -472,7 +480,7 @@ class Chat extends Emitter {
             .then(() => {
 
                 // trigger the disconnect events and update state
-                this.onDisconnected();
+                this.onLeave();
 
                 this.emit('$.system.leave', { subject: this.objectify() });
 

--- a/src/components/me.js
+++ b/src/components/me.js
@@ -83,11 +83,11 @@ class Me extends User {
         if (this.chatEngine.ceConfig.enableSync) {
 
             // subscribe to the events on our sync chat and forward them
-            this.sync.on('$.session.notify.chat.join', (payload) => {
+            this.sync.on('$.system.chat.join', (payload) => {
                 this.onSessionJoin(payload.data.subject);
             });
 
-            this.sync.on('$.session.notify.chat.leave', (payload) => {
+            this.sync.on('$.system.chat.leave', (payload) => {
                 this.onSessionLeave(payload.data.subject);
             });
 
@@ -160,7 +160,7 @@ class Me extends User {
 
             // don't rebroadcast chats in session we've already heard about
             if (!this.session[chat.group] || !this.session[chat.group][chat.channel]) {
-                this.sync.emit('$.session.notify.chat.join', { subject: chat.objectify() });
+                this.sync.emit('$.system.chat.join', { subject: chat.objectify() });
             }
         }
     }
@@ -171,7 +171,7 @@ class Me extends User {
      */
     sessionLeave(chat) {
         if (this.chatEngine.ceConfig.enableSync) {
-            this.sync.emit('$.session.notify.chat.leave', { subject: chat.objectify() });
+            this.sync.emit('$.system.chat.leave', { subject: chat.objectify() });
         }
     }
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -574,13 +574,16 @@ describe('memory', () => {
 
         let a = new ChatEngine.Chat('new-chat');
         let b = new ChatEngineYou.Chat('new-chat');
+        let doneCalled = false;
 
         let checkDone = () => {
 
             let aUsers = Object.keys(a.users);
             let bUsers = Object.keys(b.users);
 
-            if (aUsers.length > 1 && bUsers.length > 1) {
+            if (aUsers.length > 1 && bUsers.length > 1 && !doneCalled) {
+
+                doneCalled = true;
 
                 expect(Object.keys(a.users)).to.include.members(Object.keys(b.users));
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -1,4 +1,6 @@
 const assert = require('chai').assert;
+const expect = require('chai').expect;
+
 let decache = require('decache');
 
 const pubkey = 'pub-c-fab5d74d-8118-444c-b652-4a8ee0beee92';
@@ -557,6 +559,52 @@ describe('invite', () => {
         });
 
     });
+
+});
+
+describe('memory', () => {
+
+    beforeEach(reset);
+    beforeEach(createChatEngine);
+    beforeEach(createChatEngineYou);
+
+    it('should keep track of user list', function shouldKeepTrack(done) {
+
+        this.timeout(60000);
+
+        let a = new ChatEngine.Chat('new-chat');
+        let b = new ChatEngineYou.Chat('new-chat');
+
+        let checkDone = () => {
+
+            let aUsers = Object.keys(a.users);
+            let bUsers = Object.keys(b.users);
+
+            if (aUsers.length > 1 && bUsers.length > 1) {
+
+                expect(Object.keys(a.users)).to.include.members(Object.keys(b.users));
+
+                // now we test leaving
+                a.on('$.offline.leave', () => {
+                    expect(Object.keys(a.users)).to.eql([ChatEngine.me.uuid]);
+                    done();
+                });
+
+                b.leave();
+
+            }
+
+        };
+
+        a.on('$.online.*', () => {
+            checkDone();
+        });
+        b.on('$.online.*', () => {
+            checkDone();
+        });
+
+    });
+
 
 });
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -585,7 +585,7 @@ describe('memory', () => {
                 expect(Object.keys(a.users)).to.include.members(Object.keys(b.users));
 
                 // now we test leaving
-                a.on('$.offline.leave', () => {
+                a.once('$.offline.leave', () => {
                     expect(Object.keys(a.users)).to.eql([ChatEngine.me.uuid]);
                     done();
                 });


### PR DESCRIPTION
Updates the maps in chat.users before the $.online and $.offline events are fired so that when events are received, the maps correctly affect the status

Related #271 

Fixes #266 
Fixes #260 