### PR TITLE
Move session logic into own file

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -386,7 +386,11 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
             * });
             */
             ChatEngine.me.onConstructed();
-            ChatEngine.me.subscribeToSession();
+
+            if (ChatEngine.ceConfig.enableSync) {
+                ChatEngine.me.session.subscribe();
+                ChatEngine.me.session.restore();
+            }
 
             ChatEngine.me.update(state);
 
@@ -409,7 +413,6 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
             ChatEngine.subscribeToPubNub();
 
             ChatEngine.global.getUserUpdates();
-            ChatEngine.me.restoreSession();
 
         });
 

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -10,7 +10,7 @@ const Search = require('../components/search');
  @param {Boolean} [isPrivate=true] Attempt to authenticate ourselves before connecting to this {@link Chat}.
  @param {Boolean} [autoConnect=true] Connect to this chat as soon as its initiated. If set to ```false```, call the {@link Chat#connect} method to connect to this {@link Chat}.
  @param {Object} [meta={}] Chat metadata that will be persisted on the server and populated on creation.
- @param {String} [group='default'] Groups chat into a "type". This is the key which chats will be grouped into within {@link ChatEngine.session} object.
+ @param {String} [group='default'] Groups chat into a "type". This is the key which chats will be grouped into within {@link Me.session} object.
  @class Chat
  @extends Emitter
  @extends RootEmitter
@@ -618,7 +618,7 @@ class Chat extends Emitter {
          */
         this.onConnected();
 
-        if(this.chatEngine.me.session) {
+        if (this.chatEngine.me.session) {
             this.chatEngine.me.session.join(this);
         }
 

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -472,7 +472,9 @@ class Chat extends Emitter {
                 this.onDisconnected();
 
                 // tell session we've left
-                this.chatEngine.me.sessionLeave(this);
+                if (this.chatEngine.me.session) {
+                    this.chatEngine.me.session.leave(this);
+                }
 
             })
             .catch((error) => {
@@ -616,7 +618,9 @@ class Chat extends Emitter {
          */
         this.onConnected();
 
-        this.chatEngine.me.sessionJoin(this);
+        if(this.chatEngine.me.session) {
+            this.chatEngine.me.session.join(this);
+        }
 
         // add self to list of users
         this.users[this.chatEngine.me.uuid] = this.chatEngine.me;

--- a/src/components/me.js
+++ b/src/components/me.js
@@ -1,5 +1,5 @@
 const User = require('./user');
-
+const Session = require('./session');
 /**
  Represents the client connection as a special {@link User} with write permissions.
  Has the ability to update it's state on the network. An instance of
@@ -19,22 +19,12 @@ class Me extends User {
         // call the User constructor
         super(chatEngine, uuid);
 
-        this.name = 'Me';
-
         this.chatEngine = chatEngine;
 
-        /**
-         * Stores a map of {@link Chat} objects that this {@link Me} has joined across all clients.
-         * @type {Object}
-         */
-        this.session = {};
-
-        /**
-         * The {@link Chat} that syncs session between instances. Only connects
-         * if "enableSync" has been set to true in ceConfig.
-         * @type {this}
-         */
-        this.sync = new this.chatEngine.Chat([this.chatEngine.global.channel, 'user', this.uuid, 'me.', 'sync'].join('#'), false, this.chatEngine.ceConfig.enableSync, {}, 'system');
+        this.session = false;
+        if (this.chatEngine.ceConfig.enableSync) {
+            this.session = new Session(chatEngine);
+        }
 
         return this;
 
@@ -72,181 +62,6 @@ class Me extends User {
         this.chatEngine.global.setState(state);
 
     }
-
-    /**
-     * Forwards sync events from other instances into callback functions
-     * @private
-     */
-    subscribeToSession() {
-
-        // if the option has been enabled
-        if (this.chatEngine.ceConfig.enableSync) {
-
-            // subscribe to the events on our sync chat and forward them
-            this.sync.on('$.session.notify.chat.join', (payload) => {
-                this.onSessionJoin(payload.data.subject);
-            });
-
-            this.sync.on('$.session.notify.chat.leave', (payload) => {
-                this.onSessionLeave(payload.data.subject);
-            });
-
-        }
-
-    }
-
-    /**
-     * Uses PubNub channel groups to restore a session for this uuid
-     * @private
-     */
-    restoreSession() {
-
-        if (this.chatEngine.ceConfig.enableSync) {
-
-            // these are custom groups that separate custom chats from system chats
-            // for better fitlering
-            let groups = ['custom', 'system'];
-
-            // loop through the groups
-            groups.forEach((group) => {
-
-                // generate the channel group string for PubNub using the current uuid
-                let channelGroup = [this.chatEngine.ceConfig.globalChannel, this.uuid, group].join('#');
-
-                // ask pubnub for a list of channels for this group
-                this.chatEngine.pubnub.channelGroups.listChannels({
-                    channelGroup
-                }, (status, response) => {
-
-                    if (status.error) {
-                        this.chatEngine.throwError(this.chatEngine, '_emit', 'sync', new Error('There was a problem restoring your session from PubNub servers.'), { status });
-                    } else {
-
-                        // loop through the returned channels
-                        response.channels.forEach((channel) => {
-
-                            // call the same callback as if we were notified about them
-                            this.onSessionJoin({
-                                channel,
-                                private: this.chatEngine.parseChannel(channel).private,
-                                group
-                            });
-
-                            /**
-                            Fired when session has been restored at boot. Fired once per
-                            session group.
-                            @event Me#$"."session"."group"."restored
-                            */
-                            this.trigger('$.session.group.restored', { group });
-
-                        });
-
-                    }
-
-                });
-
-            });
-
-        }
-
-    }
-
-    /**
-     * Callback fired when another instance has joined a chat
-     * @private
-     */
-    sessionJoin(chat) {
-        if (this.chatEngine.ceConfig.enableSync) {
-
-            // don't rebroadcast chats in session we've already heard about
-            if (!this.session[chat.group] || !this.session[chat.group][chat.channel]) {
-                this.sync.emit('$.session.notify.chat.join', { subject: chat.objectify() });
-            }
-        }
-    }
-
-    /**
-     * Callback fired when another instance has left a chat
-     * @private
-     */
-    sessionLeave(chat) {
-        if (this.chatEngine.ceConfig.enableSync) {
-            this.sync.emit('$.session.notify.chat.leave', { subject: chat.objectify() });
-        }
-    }
-
-    /**
-    Stores {@link Chat} within ```ChatEngine.session``` keyed based on the ```chat.group``` property.
-    @param {Object} chat JSON object representing {@link Chat}. Originally supplied via {@link Chat#objectify}.
-    @private
-    */
-    onSessionJoin(chat) {
-
-        // create the chat group if it doesn't exist
-        this.session[chat.group] = this.session[chat.group] || {};
-
-        // check the chat exists within the global list but is not grouped
-        let existingChat = this.chatEngine.chats[chat.channel];
-
-        // if it exists
-        if (existingChat) {
-
-            // assign it to the group
-            this.session[chat.group][chat.channel] = existingChat;
-        } else {
-
-            // otherwise, try to recreate it with the server information
-            this.session[chat.group][chat.channel] = new this.chatEngine.Chat(chat.channel, chat.private, false, chat.meta, chat.group);
-
-            /**
-            Fired when another identical instance of {@link ChatEngine} and {@link Me} joins a {@link Chat} that this instance of {@link ChatEngine} is unaware of.
-            Used to synchronize ChatEngine sessions between desktop and mobile, duplicate windows, etc.
-            ChatEngine stores sessions on the server side identified by {@link User#uuid}.
-            @event Me#$"."session"."chat"."join
-            @example
-            *
-            * // Logged in as "Ian" in first window
-            * ChatEngine.me.on('$.session.chat.join', (data) => {
-            *     console.log('I joined a new chat in a second window!', data.chat);
-            * });
-            *
-            * // Logged in as "Ian" in second window
-            * new ChatEngine.Chat('another-chat');
-            */
-            // this.trigger('$.session.chat.join', {
-            //     chat: this.session[chat.group][chat.channel]
-            // });
-            //
-            this.trigger('$.session.chat.join', { chat: this.session[chat.group][chat.channel] });
-
-        }
-
-    }
-
-    /**
-    Removes {@link Chat} within this.session
-    @private
-    */
-    onSessionLeave(chat) {
-
-        if (this.session[chat.group] && this.session[chat.group][chat.channel]) {
-
-            chat = this.session[chat.group][chat.channel] || chat;
-
-            /**
-            * Fired when another identical instance of {@link ChatEngine} with an identical {@link Me} leaves a {@link Chat} via {@link Chat#leave}.
-            * @event Me#$"."session"."chat"."leave
-            */
-
-            delete this.chatEngine.chats[chat.channel];
-            delete this.session[chat.group][chat.channel];
-
-        }
-
-        this.trigger('$.session.chat.leave', { chat });
-
-    }
-
 }
 
 module.exports = Me;

--- a/src/components/session.js
+++ b/src/components/session.js
@@ -1,0 +1,194 @@
+const Emitter = require('../modules/emitter');
+
+class Session extends Emitter {
+
+    constructor(chatEngine) {
+
+        super(chatEngine);
+
+        this.name = 'Session';
+
+        this.chatEngine = chatEngine;
+
+        /**
+         * Stores a map of {@link Chat} objects that this {@link Me} has joined across all clients.
+         * @type {Object}
+         */
+        this.chats = {};
+
+        /**
+         * The {@link Chat} that syncs session between instances. Only connects
+         * if "enableSync" has been set to true in ceConfig.
+         * @type {this}
+         */
+        this.sync = null;
+
+    }
+
+    /**
+     * Forwards sync events from other instances into callback functions
+     * @private
+     */
+    subscribe() {
+
+        this.sync = new this.chatEngine.Chat([this.chatEngine.global.channel, 'user', this.chatEngine.me.uuid, 'me.', 'sync'].join('#'), false, this.chatEngine.ceConfig.enableSync, {}, 'system');
+
+        // subscribe to the events on our sync chat and forward them
+        this.sync.on('$.session.notify.chat.join', (payload) => {
+            this.onJoin(payload.data.subject);
+        });
+
+        this.sync.on('$.session.notify.chat.leave', (payload) => {
+            this.onleave(payload.data.subject);
+        });
+
+    }
+
+    /**
+     * Uses PubNub channel groups to restore a session for this uuid
+     * @private
+     */
+    restore() {
+
+        if (this.chatEngine.ceConfig.enableSync) {
+
+            // these are custom groups that separate custom chats from system chats
+            // for better fitlering
+            let groups = ['custom', 'system'];
+
+            // loop through the groups
+            groups.forEach((group) => {
+
+                // generate the channel group string for PubNub using the current uuid
+                let channelGroup = [this.chatEngine.ceConfig.globalChannel, this.chatEngine.me.uuid, group].join('#');
+
+                // ask pubnub for a list of channels for this group
+                this.chatEngine.pubnub.channelGroups.listChannels({
+                    channelGroup
+                }, (status, response) => {
+
+                    if (status.error) {
+                        this.chatEngine.throwError(this.chatEngine, '_emit', 'sync', new Error('There was a problem restoring your session from PubNub servers.'), { status });
+                    } else {
+
+                        // loop through the returned channels
+                        response.channels.forEach((channel) => {
+
+                            // call the same callback as if we were notified about them
+                            this.onJoin({
+                                channel,
+                                private: this.chatEngine.parseChannel(channel).private,
+                                group
+                            });
+
+                            /**
+                            Fired when session has been restored at boot. Fired once per
+                            session group.
+                            @event Me#$"."session"."group"."restored
+                            */
+                            this.trigger('$.session.group.restored', { group });
+
+                        });
+
+                    }
+
+                });
+
+            });
+
+        }
+
+    }
+
+    /**
+     * Callback fired when another instance has joined a chat
+     * @private
+     */
+    join(chat) {
+
+        // don't rebroadcast chats in session we've already heard about
+        if (!this.chats[chat.group] || !this.chats[chat.group][chat.channel]) {
+            this.sync.emit('$.session.notify.chat.join', { subject: chat.objectify() });
+        }
+
+    }
+
+    /**
+     * Callback fired when another instance has left a chat
+     * @private
+     */
+    leave(chat) {
+        this.sync.emit('$.session.notify.chat.leave', { subject: chat.objectify() });
+    }
+
+    /**
+    Stores {@link Chat} within ```ChatEngine.session``` keyed based on the ```chat.group``` property.
+    @param {Object} chat JSON object representing {@link Chat}. Originally supplied via {@link Chat#objectify}.
+    @private
+    */
+    onJoin(chat) {
+
+        // create the chat group if it doesn't exist
+        this.chats[chat.group] = this.chats[chat.group] || {};
+
+        // check the chat exists within the global list but is not grouped
+        let existingChat = this.chatEngine.chats[chat.channel];
+
+        // if it exists
+        if (existingChat) {
+
+            // assign it to the group
+            this.chats[chat.group][chat.channel] = existingChat;
+        } else {
+
+            // otherwise, try to recreate it with the server information
+            this.chats[chat.group][chat.channel] = new this.chatEngine.Chat(chat.channel, chat.private, false, chat.meta, chat.group);
+
+            /**
+            Fired when another identical instance of {@link ChatEngine} and {@link Me} joins a {@link Chat} that this instance of {@link ChatEngine} is unaware of.
+            Used to synchronize ChatEngine sessions between desktop and mobile, duplicate windows, etc.
+            ChatEngine stores sessions on the server side identified by {@link User#uuid}.
+            @event Me#$"."session"."chat"."join
+            @example
+            *
+            * // Logged in as "Ian" in first window
+            * ChatEngine.me.on('$.session.chat.join', (data) => {
+            *     console.log('I joined a new chat in a second window!', data.chat);
+            * });
+            *
+            * // Logged in as "Ian" in second window
+            * new ChatEngine.Chat('another-chat');
+            */
+            this.trigger('$.session.chat.join', { chat: this.chats[chat.group][chat.channel] });
+
+        }
+
+    }
+
+    /**
+    Removes {@link Chat} within this.chats
+    @private
+    */
+    onleave(chat) {
+
+        if (this.chats[chat.group] && this.chats[chat.group][chat.channel]) {
+
+            chat = this.chats[chat.group][chat.channel] || chat;
+
+            /**
+            * Fired when another identical instance of {@link ChatEngine} with an identical {@link Me} leaves a {@link Chat} via {@link Chat#leave}.
+            * @event Me#$"."session"."chat"."leave
+            */
+
+            delete this.chatEngine.chats[chat.channel];
+            delete this.chats[chat.group][chat.channel];
+
+        }
+
+        this.trigger('$.session.chat.leave', { chat });
+
+    }
+
+}
+
+module.exports = Session;

--- a/src/components/session.js
+++ b/src/components/session.js
@@ -84,7 +84,7 @@ class Session extends Emitter {
                         session group.
                         @event Me#$"."session"."group"."restored
                         */
-                        this.trigger('$.session.group.restored', { group });
+                        this.trigger('$.group.restored', { group });
 
                     });
 
@@ -148,14 +148,14 @@ class Session extends Emitter {
             @example
             *
             * // Logged in as "Ian" in first window
-            * ChatEngine.me.on('$.session.chat.join', (data) => {
+            * ChatEngine.me.session.on('$.chat.join', (data) => {
             *     console.log('I joined a new chat in a second window!', data.chat);
             * });
             *
             * // Logged in as "Ian" in second window
             * new ChatEngine.Chat('another-chat');
             */
-            this.trigger('$.session.chat.join', { chat: this.chats[chat.group][chat.channel] });
+            this.trigger('$.chat.join', { chat: this.chats[chat.group][chat.channel] });
 
         }
 
@@ -181,7 +181,7 @@ class Session extends Emitter {
 
         }
 
-        this.trigger('$.session.chat.leave', { chat });
+        this.trigger('$.chat.leave', { chat });
 
     }
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -447,7 +447,7 @@ describe('remote chat list', () => {
         this.timeout(60000);
 
         // first instance looking or new chats
-        ChatEngineSync.me.session.on('$.session.chat.join', (payload) => {
+        ChatEngineSync.me.session.on('$.chat.join', (payload) => {
 
             if (payload.chat.channel.indexOf(newChannel) > -1) {
                 done();
@@ -467,7 +467,7 @@ describe('remote chat list', () => {
 
         this.timeout(60000);
 
-        ChatEngineSync.me.session.once('$.session.group.restored', (payload) => {
+        ChatEngineSync.me.session.once('$.group.restored', (payload) => {
 
             assert.isObject(ChatEngineSync.me.session.chats[payload.group]);
             done();
@@ -483,7 +483,7 @@ describe('remote chat list', () => {
         let newChannel2 = 'sync-chat2' + new Date().getTime();
         let syncChat;
 
-        ChatEngineSync.me.session.on('$.session.chat.leave', (payload) => {
+        ChatEngineSync.me.session.on('$.chat.leave', (payload) => {
 
             if (payload.chat.channel.indexOf(newChannel2) > -1) {
                 done();

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -447,7 +447,7 @@ describe('remote chat list', () => {
         this.timeout(60000);
 
         // first instance looking or new chats
-        ChatEngineSync.me.on('$.session.chat.join', (payload) => {
+        ChatEngineSync.me.session.on('$.session.chat.join', (payload) => {
 
             if (payload.chat.channel.indexOf(newChannel) > -1) {
                 done();
@@ -467,9 +467,9 @@ describe('remote chat list', () => {
 
         this.timeout(60000);
 
-        ChatEngineSync.me.once('$.session.group.restored', (payload) => {
+        ChatEngineSync.me.session.once('$.session.group.restored', (payload) => {
 
-            assert.isObject(ChatEngineSync.me.session[payload.group]);
+            assert.isObject(ChatEngineSync.me.session.chats[payload.group]);
             done();
 
         });
@@ -483,7 +483,7 @@ describe('remote chat list', () => {
         let newChannel2 = 'sync-chat2' + new Date().getTime();
         let syncChat;
 
-        ChatEngineSync.me.on('$.session.chat.leave', (payload) => {
+        ChatEngineSync.me.session.on('$.session.chat.leave', (payload) => {
 
             if (payload.chat.channel.indexOf(newChannel2) > -1) {
                 done();

--- a/test/unit/components/me.test.js
+++ b/test/unit/components/me.test.js
@@ -19,6 +19,7 @@ describe('#me', () => {
         chatEngineInstance.connect();
 
         me = new Me(chatEngineInstance, 'user1');
+        me.session.subscribe();
     });
 
     it('chat created', (done) => {
@@ -28,9 +29,9 @@ describe('#me', () => {
 
     it('chat sync created', (done) => {
 
-        me.subscribeToSession();
+        me.session.subscribe();
 
-        assert.isObject(me.sync);
+        assert.isObject(me.session.chats);
 
         done();
     });
@@ -42,7 +43,7 @@ describe('#me', () => {
             done();
         });
 
-        me.sync.trigger('$.session.chat.join', { chat: { group: 'default', channel: 'test' } });
+        me.session.sync.trigger('$.session.chat.join', { chat: { group: 'default', channel: 'test' } });
 
     });
 
@@ -53,7 +54,7 @@ describe('#me', () => {
             done();
         });
 
-        me.sync.trigger('$.session.chat.leave', { chat: { group: 'default', channel: 'test' } });
+        me.session.sync.trigger('$.session.chat.leave', { chat: { group: 'default', channel: 'test' } });
 
     });
 });


### PR DESCRIPTION
This introduces breaking changes the API:

```
ChatEngine.me.on('$.session.chat.leave', (payload) => {});
```
Into
```
ChatEngine.me.session.on('$.chat.leave', (payload) => {});
```

I believe this is superior. It isolates the session logic from ```Me``` and provides a better interface for enabling and disabling it.

Session functionality should really be a plugin. This is a halfway mark to that.