### PR TITLE
Chat 185 - Expose Timetoken on Emit

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -241,6 +241,8 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
         ChatEngine.pubnub.addListener({
             message: (m) => {
 
+                m.message.timetoken = m.timetoken;
+
                 if (ChatEngine.chats[m.channel]) {
                     ChatEngine.chats[m.channel].trigger(m.message.event, m.message);
                 }

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -71,8 +71,6 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
 
     ChatEngine.throwError = (self, cb, key, ceError, payload = {}) => {
 
-        // console.log(self, cb, key, ceError, payload);
-
         if (ceConfig.throwErrors) {
             // throw ceError;
             console.error(payload);
@@ -245,8 +243,6 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
 
                 if (ChatEngine.chats[m.channel]) {
                     ChatEngine.chats[m.channel].trigger(m.message.event, m.message);
-                } else {
-                    console.log('message missed', m);
                 }
 
             },
@@ -254,8 +250,6 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
 
                 if (ChatEngine.chats[payload.channel]) {
                     ChatEngine.chats[payload.channel].onPresence(payload);
-                } else {
-                    console.log('message missed', payload.channel);
                 }
 
             },

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -71,6 +71,8 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
 
     ChatEngine.throwError = (self, cb, key, ceError, payload = {}) => {
 
+        // console.log(self, cb, key, ceError, payload);
+
         if (ceConfig.throwErrors) {
             // throw ceError;
             console.error(payload);
@@ -239,10 +241,21 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
          @param {Object} statusEvent The response status
          */
         ChatEngine.pubnub.addListener({
+            message: (m) => {
+
+                if (ChatEngine.chats[m.channel]) {
+                    ChatEngine.chats[m.channel].trigger(m.message.event, m.message);
+                } else {
+                    console.log('message missed', m);
+                }
+
+            },
             presence: (payload) => {
 
                 if (ChatEngine.chats[payload.channel]) {
                     ChatEngine.chats[payload.channel].onPresence(payload);
+                } else {
+                    console.log('message missed', payload.channel);
                 }
 
             },
@@ -372,7 +385,6 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
         ChatEngine.global = new ChatEngine.Chat(ceConfig.globalChannel, false, true, {}, 'system');
 
         ChatEngine.global.once('$.connected', () => {
-
 
             // build the current user
             ChatEngine.me = new Me(ChatEngine, ChatEngine.pnConfig.uuid);

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -241,6 +241,7 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
         ChatEngine.pubnub.addListener({
             message: (m) => {
 
+                // assign the message timetoken as a property of the payload
                 m.message.timetoken = m.timetoken;
 
                 if (ChatEngine.chats[m.channel]) {

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -312,7 +312,6 @@ class Chat extends Emitter {
             // publish the event and data over the configured channel
 
             // ensure the event exists within the global space
-
             tracer.publish(pluginResponse);
 
         });

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -310,8 +310,6 @@ class Chat extends Emitter {
             delete pluginResponse.chat;
 
             // publish the event and data over the configured channel
-
-            // ensure the event exists within the global space
             tracer.publish(pluginResponse);
 
         });

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -297,6 +297,8 @@ class Chat extends Emitter {
             chatengineSDK: this.chatEngine.package.version
         };
 
+        let tracer = new Event(this.chatEngine, this, event);
+
         // run the plugin queue to modify the event
         this.runPluginQueue('emit', event, (next) => {
             next(null, payload);
@@ -310,11 +312,12 @@ class Chat extends Emitter {
             // publish the event and data over the configured channel
 
             // ensure the event exists within the global space
-            this.events[event] = this.events[event] || new Event(this.chatEngine, this, event);
 
-            this.events[event].publish(pluginResponse);
+            tracer.publish(pluginResponse);
 
         });
+
+        return tracer;
 
     }
 

--- a/src/components/event.js
+++ b/src/components/event.js
@@ -68,7 +68,9 @@ class Event extends RootEmitter {
 
             if (status.statusCode === 200) {
 
-                m.timetoken = response.timetoken;
+                if (response) {
+                    m.timetoken = response.timetoken;
+                }
 
                 /**
                  * Message successfully published

--- a/src/components/event.js
+++ b/src/components/event.js
@@ -1,10 +1,14 @@
+const RootEmitter = require('../modules/root_emitter');
+
 /**
  * @class Event
  * Represents an event that may be emitted or subscribed to.
  */
-class Event {
+class Event extends RootEmitter {
 
     constructor(chatEngine, chat, event) {
+
+        super();
 
         /**
          Events are always a property of a {@link Chat}. Responsible for
@@ -60,16 +64,19 @@ class Event {
         this.chatEngine.pubnub.publish({
             message: m,
             channel: this.channel
-        }, (status) => {
+        }, (status, response) => {
 
             if (status.statusCode === 200) {
+
+                m.timetoken = response.timetoken;
 
                 /**
                  * Message successfully published
                  * @event Chat#$"."publish"."success
                  * @param {Object} data The message object
                  */
-                this.chat.trigger('$.publish.success', m);
+                this._emit('$.emitted', m);
+
             } else {
 
                 /**

--- a/src/components/event.js
+++ b/src/components/event.js
@@ -1,10 +1,10 @@
-const RootEmitter = require('../modules/root_emitter');
+const Emitter = require('../modules/root_emitter');
 
 /**
  * @class Event
  * Represents an event that may be emitted or subscribed to.
  */
-class Event extends RootEmitter {
+class Event extends Emitter {
 
     constructor(chatEngine, chat, event) {
 
@@ -34,20 +34,7 @@ class Event extends RootEmitter {
          @param {Object} data The event payload object
          */
 
-        // call onMessage when PubNub receives an event
-        this.chatEngine.pubnub.addListener({
-            message: this.onMessage.bind(this)
-        });
-
         return this;
-
-    }
-
-    onMessage(m) {
-
-        if (this.channel === m.channel && m.message.event === this.event) {
-            this.chat.trigger(m.message.event, m.message);
-        }
 
     }
 

--- a/src/components/event.js
+++ b/src/components/event.js
@@ -83,7 +83,7 @@ class Event extends RootEmitter {
                  * There was a problem publishing over the PubNub network.
                  * @event Chat#$"."error"."publish
                  */
-                this.chatEngine.throwError(this.chat, 'trigger', 'publish', new Error('There was a problem publishing over the PubNub network.'), status);
+                this.chatEngine.throwError(this, '_emit', 'emitter', new Error('There was a problem publishing over the PubNub network.'), status);
             }
 
         });

--- a/src/components/event.js
+++ b/src/components/event.js
@@ -2,7 +2,10 @@ const Emitter = require('../modules/root_emitter');
 
 /**
  * @class Event
- * Represents an event that may be emitted or subscribed to.
+ * Represents an {@link Chat} event.
+ * @fires $"."emitted
+ * @extends Emitter
+ * @extends RootEmitter
  */
 class Event extends Emitter {
 
@@ -11,28 +14,37 @@ class Event extends Emitter {
         super();
 
         /**
-         Events are always a property of a {@link Chat}. Responsible for
-         listening to specific events and firing events when they occur.
-         @readonly
-         @type String
-         @see [PubNub Channels](https://support.pubnub.com/support/solutions/articles/14000045182-what-is-a-channel-)
+         * @private
+         */
+        this.chatEngine = chatEngine;
+
+        /**
+         * The {@link Chat#channel} that this event is registered to.
+         * @type String
+         * @see [PubNub Channels](https://support.pubnub.com/support/solutions/articles/14000045182-what-is-a-channel-)
+         * @readonly
          */
         this.channel = chat.channel;
 
-        this.chatEngine = chatEngine;
-
+        /**
+         * Events are always a property of a {@link Chat}. Responsible for
+         * listening to specific events and firing events when they occur.
+         * @readonly
+         * @type {Chat}
+         */
         this.chat = chat;
 
+        /**
+         * The string representation of the event. This is supplied as the first parameter to {@link Chat#on}
+         * @type {String}
+         */
         this.event = event;
 
-        this.name = 'Event';
-
         /**
-         Forwards events to the Chat that registered the event {@link Chat}
-
-         @private
-         @param {Object} data The event payload object
+         * A name that identifies this class
+         * @type {String}
          */
+        this.name = 'Event';
 
         return this;
 
@@ -61,8 +73,8 @@ class Event extends Emitter {
 
                 /**
                  * Message successfully published
-                 * @event Chat#$"."publish"."success
-                 * @param {Object} data The message object
+                 * @event Event#$"."emitted"
+                 * @param {Object} data The message payload
                  */
                 this._emit('$.emitted', m);
 
@@ -82,3 +94,4 @@ class Event extends Emitter {
 }
 
 module.exports = Event;
+

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -121,6 +121,7 @@ class Search extends Emitter {
                 middleware: {
                     on: {
                         '*': (payload, next) => {
+
                             let matches = payload && payload.event && payload.event === event;
                             next(!matches, payload);
                         }
@@ -134,6 +135,7 @@ class Search extends Emitter {
                 middleware: {
                     on: {
                         '*': (payload, next) => {
+
                             let matches = payload && payload.sender && payload.sender.uuid === user.uuid;
                             next(!matches, payload);
                         }

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -125,8 +125,6 @@ class User extends Emitter {
 
             this._stateInProgress = true;
 
-            console.log('trying to getState');
-
             this.chatEngine.pubnub.getState({
                 uuid: this.uuid,
                 channels: [this.chatEngine.global.channel]
@@ -158,7 +156,6 @@ class User extends Emitter {
                     }
 
                 } else {
-                    console.log(status, response)
                     this.chatEngine.throwError(this, 'trigger', 'getState', new Error('There was a problem getting user state from the PubNub network.'));
                 }
 

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -26,6 +26,7 @@ class User extends Emitter {
          @readonly
          @type String
          */
+
         this.uuid = uuid;
 
         /**
@@ -124,6 +125,8 @@ class User extends Emitter {
 
             this._stateInProgress = true;
 
+            console.log('trying to getState');
+
             this.chatEngine.pubnub.getState({
                 uuid: this.uuid,
                 channels: [this.chatEngine.global.channel]
@@ -140,25 +143,22 @@ class User extends Emitter {
 
                     } else {
 
-
                         this.chatEngine.request('get', 'user_state', {
                             user: this.uuid
-                        })
-                            .then((res) => {
+                        }).then((res) => {
 
-                                this.assign(res.data);
-                                this._stateFetched = true;
-                                callback(this.state);
+                            this.assign(res.data);
+                            this._stateFetched = true;
+                            callback(this.state);
 
-                            })
-                            .catch((err) => {
-                                // console.log('this is hte err', err);
-                                this.chatEngine.throwError(this, 'trigger', 'getState', err);
-                            });
+                        }).catch((err) => {
+                            this.chatEngine.throwError(this, 'trigger', 'getState', err);
+                        });
 
                     }
 
                 } else {
+                    console.log(status, response)
                     this.chatEngine.throwError(this, 'trigger', 'getState', new Error('There was a problem getting user state from the PubNub network.'));
                 }
 
@@ -169,6 +169,7 @@ class User extends Emitter {
         }
 
     }
+
 
 }
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -286,7 +286,8 @@ describe('chat', () => {
         let event = chat.emit('test');
 
         event.on('$.emitted', (a) => {
-            console.log(a);
+            assert(a.timetoken, 'Timetoken exposed on emit');
+            done();
         });
 
     });

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -277,6 +277,22 @@ describe('chat', () => {
     beforeEach(reset);
     beforeEach(createChatEngine);
 
+    it('should get timetoken from publish callback', function getTimetoken(done) {
+
+        this.timeout(60000);
+
+        let chat = new ChatEngine.Chat('chat-tester' + new Date().getTime());
+
+        let event = chat.emit('test');
+
+        // console.log('returned', event )
+
+        event.on('$.emitted', (a) => {
+            console.log(a);
+        });
+
+    });
+
     it('should get me as join event', function getMe(done) {
 
         this.timeout(60000);

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -285,8 +285,6 @@ describe('chat', () => {
 
         let event = chat.emit('test');
 
-        // console.log('returned', event )
-
         event.on('$.emitted', (a) => {
             console.log(a);
         });

--- a/test/unit/components/event.test.js
+++ b/test/unit/components/event.test.js
@@ -32,7 +32,8 @@ describe('#event', () => {
     });
 
     it('should emit a message', (done) => {
-        chat.on('$.publish.success', () => {
+
+        event.on('$.emitted', () => {
             done();
         });
 

--- a/test/unit/components/event.test.js
+++ b/test/unit/components/event.test.js
@@ -44,12 +44,4 @@ describe('#event', () => {
 
     });
 
-    it('should receive a message', (done) => {
-        chat.on('event_test', (payload) => {
-            assert(payload.message === 'hello', 'got the expected value');
-            done();
-        });
-
-        event.onMessage({ channel: chat.channel, message: { event: 'event_test', message: 'hello' } });
-    });
 });


### PR DESCRIPTION
This makes a ```new Event``` for every publish so that we can track the network status of that communication. 

For example, here is how to grab the timetoken response on a successful publish:

```js
        let chat = new ChatEngine.Chat('chat-tester' + new Date().getTime());

        let event = chat.emit('test');

        event.on('$.emitted', (a) => {
            assert(a.timetoken, 'Timetoken exposed on emit');
            console.log(a.timetoken);
            done();
        });
```