### PR TITLE
CHAT-246 - Attempt to stop uuids from being set as objects

### DIFF
--- a/src/components/user.js
+++ b/src/components/user.js
@@ -27,6 +27,10 @@ class User extends Emitter {
          @type String
          */
 
+        if (typeof uuid !== 'string') {
+            this.chatEngine.throwError(this, 'trigger', 'construct', new Error('UUID must be of type string'));
+        }
+
         this.uuid = uuid;
 
         /**

--- a/src/modules/emitter.js
+++ b/src/modules/emitter.js
@@ -190,7 +190,7 @@ class Emitter extends RootEmitter {
             }
 
             // if we should try to restore the sender property
-            if (payload.sender) {
+            if (payload.sender && typeof payload.sender === 'string') {
 
                 // the user doesn't exist, create it
                 payload.sender = new this.chatEngine.User(payload.sender);


### PR DESCRIPTION
I believe we had a problem where a message could be augmented with the sender twice. See #319 