### PR TITLE
Properly Load Babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "author": "PubNub",
   "name": "chat-engine",
-  "version": "0.9.5",
+  "version": "0.9.7",
   "description": "ChatEngine",
-  "main": "src/index.js",
+  "main": "dist/chat-engine.js",
   "scripts": {
+    "build": "gulp",
     "deploy": "gulp; npm publish;",
     "docs": "jsdoc src/index.js -c jsdoc.json"
   },
@@ -23,6 +24,8 @@
   },
   "homepage": "https://github.com/pubnub/chat-engine#readme",
   "devDependencies": {
+    "babel-loader": "^7.1.4",
+    "babel-preset-env": "^1.6.1",
     "body-parser": "^1.17.2",
     "chai": "^3.5.0",
     "chat-engine-typing-indicator": "0.0.x",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,19 @@
 let StatsPlugin = require('stats-webpack-plugin');
 
 let config = {
-    entry: ['babel-polyfill', './src/index.js'],
     module: {
-        loaders: [
-            { test: /\.json/, loader: 'json-loader' },
+        rules: [
+            { test: /\.json/, use: 'json-loader' },
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['env']
+                    }
+                }
+            }
         ],
     },
     output: {


### PR DESCRIPTION
Thanks to @adamtyler for the original commit. [The React example](https://github.com/pubnub/chat-engine-examples/tree/create-react-app/react) was also updated to use create-react-app.