### PR TITLE
Chat 295 - Chat Meta Feature Flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "webpack-stream": "^4.0.0"
   },
   "dependencies": {
-    "async": "^2.1.2",
-    "axios": "^0.16.2",
-    "eventemitter2": "^2.2.1",
-    "pubnub": "^4.20.1"
+    "async": "2.1.2",
+    "axios": "0.16.2",
+    "eventemitter2": "2.2.1",
+    "pubnub": "4.20.2"
   }
 }

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -95,7 +95,7 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
 
         let countObject = {};
 
-        ChatEngine.onAny((event, payload) => {
+        ChatEngine.onAny((event) => {
             countObject['event: ' + event] = countObject[event] || 0;
             countObject['event: ' + event] += 1;
         });

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -354,7 +354,7 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
 
         // create a new chat to use as global chat
         // we don't do auth on this one because it's assumed to be done with the /auth request below
-        ChatEngine.global = new ChatEngine.Chat(ceConfig.globalChannel, false, true, {}, 'custom');
+        ChatEngine.global = new ChatEngine.Chat(ceConfig.globalChannel, false, true, {}, 'system');
 
         ChatEngine.global.once('$.connected', () => {
 

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -354,7 +354,7 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
 
         // create a new chat to use as global chat
         // we don't do auth on this one because it's assumed to be done with the /auth request below
-        ChatEngine.global = new ChatEngine.Chat(ceConfig.globalChannel, false, true, {}, 'system');
+        ChatEngine.global = new ChatEngine.Chat(ceConfig.globalChannel, false, true, {}, 'custom');
 
         ChatEngine.global.once('$.connected', () => {
 

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -711,7 +711,7 @@ class Chat extends Emitter {
             },
             (next) => {
 
-                if(this.group === 'custom' && this.chatEngine.ceConfig.enableMeta) {
+                if (this.group === 'custom' && this.chatEngine.ceConfig.enableMeta) {
 
                     this.chatEngine.request('get', 'chat', {}, { channel: this.channel })
                         .then((response) => {
@@ -738,10 +738,10 @@ class Chat extends Emitter {
             // now that we've got connection, do everything else via connectionReady
             this.connectionReady();
 
-            if(error) {
+            if (error) {
                 this.chatEngine.throwError(this, 'trigger', 'auth', new Error('Something went wrong while making a request to authentication server.'), { error });
             } else {
-
+                callback();
             }
 
         });

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -727,7 +727,7 @@ class Chat extends Emitter {
             (next) => {
 
 
-                if(this.chatEngine.ceConfig.enableMeta) {
+                if (this.chatEngine.ceConfig.enableMeta) {
 
                     this.chatEngine.request('get', 'chat', {}, { channel: this.channel })
                         .then((response) => {

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -422,7 +422,7 @@ class Chat extends Emitter {
     wake() {
 
         if (this.asleep) {
-            this.handshake(() => {
+            this.connect(() => {
                 this.onConnected();
             });
         }

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -161,8 +161,6 @@ class Chat extends Emitter {
      */
     invite(user) {
 
-        console.log('user invite called')
-
         this.chatEngine.request('post', 'invite', {
             to: user.uuid,
             chat: this.objectify()
@@ -170,8 +168,6 @@ class Chat extends Emitter {
             .then(() => {
 
                 let send = () => {
-
-                    console.log('emitting invite')
 
                     /**
                      * Notifies {@link Me} that they've been invited to a new private {@link Chat}.

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -161,6 +161,8 @@ class Chat extends Emitter {
      */
     invite(user) {
 
+        console.log('user invite called')
+
         this.chatEngine.request('post', 'invite', {
             to: user.uuid,
             chat: this.objectify()
@@ -168,6 +170,8 @@ class Chat extends Emitter {
             .then(() => {
 
                 let send = () => {
+
+                    console.log('emitting invite')
 
                     /**
                      * Notifies {@link Me} that they've been invited to a new private {@link Chat}.
@@ -711,12 +715,10 @@ class Chat extends Emitter {
             },
             (next) => {
 
-                if(this.group === 'custom' && this.chatEngine.enableMeta) {
+                if(this.group === 'custom' && this.chatEngine.ceConfig.enableMeta) {
 
                     this.chatEngine.request('get', 'chat', {}, { channel: this.channel })
                         .then((response) => {
-
-                            console.log('response', response)
 
                             // asign metadata locally
                             if (response.data.found) {

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,10 @@ const create = (pnConfig, ceConfig = {}) => {
         ceConfig.enableSync = false;
     }
 
+    if (typeof ceConfig.enableMeta === 'undefined') {
+        ceConfig.enableMeta = false;
+    }
+
     ceConfig.endpoint = ceConfig.endpoint || 'https://pubsub.pubnub.com/v1/blocks/sub-key/' + pnConfig.subscribeKey + '/chat-engine-server';
 
     pnConfig.heartbeatInterval = pnConfig.heartbeatInterval || 30;

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ Global object used to create an instance of {@link ChatEngine}.
 @param ceConfig {Object} A list of ChatEngine specific configuration options.
 @param [ceConfig.globalChannel=chat-engine] {String} The root channel. See {@link ChatEngine.global}
 @param [ceConfig.enableSync] {Boolean} Synchronizes chats between instances with the same {@link Me#uuid}. See {@link Me#sync}.
+@param [ceConfig.enableMeta] {Boolean} Persists {@link Chat#meta} on the server. See {@link Chat#update}.
 @param [ceConfig.throwErrors=true] {Boolean} Throws errors in JS console.
 @param [ceConfig.endpoint='https://pubsub.pubnub.com/v1/blocks/sub-key/YOUR_SUB_KEY/chat-engine-server'] {String} The root URL of the server used to manage permissions for private channels. Set by default to match the PubNub functions deployed to your account. See {@tutorial privacy} for more.
 @param [ceConfig.debug] {Boolean} Logs all ChatEngine events to the console This should not be enabled in production.

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -566,7 +566,7 @@ describe('meta', () => {
 
         this.timeout(60000);
 
-        let meta = {works: true};
+        let meta = { works: true };
 
         let chat = new ChatEngine.Chat('chat-tester' + new Date().getTime(), false, true, meta);
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -154,6 +154,25 @@ function createChatEngineConnect(done) {
 
 }
 
+function createChatEngineMeta(done) {
+
+    this.timeout(60000);
+
+    ChatEngine = require('../../src/index.js').create({
+        publishKey: pubkey,
+        subscribeKey: subkey
+    }, {
+        globalChannel,
+        throwErrors: true,
+        enableMeta: true
+    });
+    ChatEngine.connect(username, { works: true }, username);
+    ChatEngine.on('$.ready', () => {
+        done();
+    });
+
+}
+
 let examplePlugin = () => {
 
     class extension {
@@ -536,6 +555,28 @@ describe('history', () => {
             });
         });
     });
+});
+
+describe('meta', () => {
+
+    beforeEach(reset);
+    beforeEach(createChatEngineMeta);
+
+    it('should update meta', function getMeta(done) {
+
+        this.timeout(60000);
+
+        let meta = {works: true};
+
+        let chat = new ChatEngine.Chat('chat-tester' + new Date().getTime(), false, true, meta);
+
+        chat.on('$.connected', () => {
+            assert.equal(chat.meta, meta);
+            done();
+        });
+
+    });
+
 });
 
 describe('remote chat list', () => {

--- a/test/unit/components/chat.test.js
+++ b/test/unit/components/chat.test.js
@@ -29,7 +29,8 @@ describe('#chat', () => {
     });
 
     it('connect chat', (done) => {
-        chatInstance.on('$.connected', () => {
+
+        chatInstance.once('$.connected', () => {
             done();
         });
 
@@ -57,7 +58,7 @@ describe('#chat', () => {
 
     it('user join to chat', (done) => {
 
-        chatInstance.on('$.online.join', () => {
+        chatInstance.once('$.online.join', () => {
             done();
         });
 


### PR DESCRIPTION
This pull request turns chat metadata syncing into a feature flag. Previously it was enabled by default for every chat which resulted in many wasteful network calls.

- Enable meta again with ```ceConfig.enableMeta```
- Only possible to add metadata to custom chats
- Global chat is now ```custom``` type
