### PR TITLE
Don't store $.system.leave in history

### DIFF
--- a/src/components/event.js
+++ b/src/components/event.js
@@ -60,9 +60,17 @@ class Event extends Emitter {
 
         m.event = this.event;
 
+        let storeInHistory = true;
+
+        // don't store in history if $.system event
+        if(!this.event.indexOf('$.system')) {
+            storeInHistory = false;
+        }
+
         this.chatEngine.pubnub.publish({
             message: m,
-            channel: this.channel
+            channel: this.channel,
+            storeInHistory
         }, (status, response) => {
 
             if (status.statusCode === 200) {

--- a/src/components/event.js
+++ b/src/components/event.js
@@ -63,7 +63,7 @@ class Event extends Emitter {
         let storeInHistory = true;
 
         // don't store in history if $.system event
-        if(!this.event.indexOf('$.system')) {
+        if (!this.event.indexOf('$.system')) {
             storeInHistory = false;
         }
 


### PR DESCRIPTION
These system events clog the history log with large number of users. They are not relevant to message history and therefore we should not store them.

This also opens up the ability for us to use $.system events in other cases.