### PR TITLE
Update logic so that hereNow sets enough state for each user

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -376,27 +376,29 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
                 ChatEngine.me.session.restore();
             }
 
-            ChatEngine.me.update(state);
+            ChatEngine.me.update(state, () => {
 
-            /**
-             *  Fired when ChatEngine is connected to the internet and ready to go!
-             * @event ChatEngine#$"."ready
-             * @example
-             * ChatEngine.on('$.ready', (data) => {
-             *     let me = data.me;
-             * })
-             */
+                /**
+                 *  Fired when ChatEngine is connected to the internet and ready to go!
+                 * @event ChatEngine#$"."ready
+                 * @example
+                 * ChatEngine.on('$.ready', (data) => {
+                 *     let me = data.me;
+                 * })
+                 */
 
-            ChatEngine._emit('$.ready', {
-                me: ChatEngine.me
+                ChatEngine._emit('$.ready', {
+                    me: ChatEngine.me
+                });
+
+                ChatEngine.ready = true;
+
+                ChatEngine.listenToPubNub();
+                ChatEngine.subscribeToPubNub();
+
+                ChatEngine.global.getUserUpdates();
+
             });
-
-            ChatEngine.ready = true;
-
-            ChatEngine.listenToPubNub();
-            ChatEngine.subscribeToPubNub();
-
-            ChatEngine.global.getUserUpdates();
 
         });
 

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -6,7 +6,7 @@ const RootEmitter = require('./modules/root_emitter');
 const Chat = require('./components/chat');
 const Me = require('./components/me');
 const User = require('./components/user');
-const series = require('async/series');
+const waterfall = require('async/waterfall');
 
 /**
 @class ChatEngine
@@ -199,7 +199,7 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
      */
     ChatEngine.handshake = (complete) => {
 
-        series([
+        waterfall([
             (next) => {
                 ChatEngine.request('post', 'bootstrap').then(() => {
                     next(null);
@@ -216,12 +216,18 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
                 }).catch(next);
             },
             (next) => {
-                ChatEngine.request('post', 'group').then(complete).catch(next);
+                ChatEngine.request('post', 'group').then(() =>{
+                    next();
+                }).catch(next);
             }
         ], (error) => {
+
             if (error) {
                 ChatEngine.throwError(ChatEngine, '_emit', 'auth', new Error('There was a problem logging into the auth server (' + ceConfig.endpoint + ').' + error && error.response && error.response.data), { error });
+            } else {
+                complete();
             }
+
         });
 
     };
@@ -373,7 +379,6 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
 
             if (ChatEngine.ceConfig.enableSync) {
                 ChatEngine.me.session.subscribe();
-                ChatEngine.me.session.restore();
             }
 
             ChatEngine.me.update(state, () => {
@@ -386,7 +391,6 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
                  *     let me = data.me;
                  * })
                  */
-
                 ChatEngine._emit('$.ready', {
                     me: ChatEngine.me
                 });
@@ -396,7 +400,11 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
                 ChatEngine.listenToPubNub();
                 ChatEngine.subscribeToPubNub();
 
-                ChatEngine.global.getUserUpdates();
+                ChatEngine.global.getUserUpdates()
+
+                if (ChatEngine.ceConfig.enableSync) {
+                    ChatEngine.me.session.restore();
+                }
 
             });
 

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -216,7 +216,7 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
                 }).catch(next);
             },
             (next) => {
-                ChatEngine.request('post', 'group').then(() =>{
+                ChatEngine.request('post', 'group').then(() => {
                     next();
                 }).catch(next);
             }
@@ -400,7 +400,7 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
                 ChatEngine.listenToPubNub();
                 ChatEngine.subscribeToPubNub();
 
-                ChatEngine.global.getUserUpdates()
+                ChatEngine.global.getUserUpdates();
 
                 if (ChatEngine.ceConfig.enableSync) {
                     ChatEngine.me.session.restore();

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -748,10 +748,10 @@ class Chat extends Emitter {
 
             }
         ], (error) => {
-            if(error) {
 
+            if (error) {
                 this.chatEngine.throwError(this, 'trigger', 'auth', new Error('Something went wrong while making a request to authentication server.'), { error });
-            }else {
+            } else {
                 complete();
             }
         });

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -694,7 +694,7 @@ class Chat extends Emitter {
      * // connect to the chat when we feel like it
      * chat.connect();
      */
-    handshake(callback) {
+    handshake(complete) {
 
         waterfall([
             (next) => {
@@ -737,18 +737,23 @@ class Chat extends Emitter {
                                 this.update(this.meta);
                             }
 
-                            callback();
+                            next();
 
                         })
                         .catch(next);
 
                 } else {
-                    callback();
+                    next();
                 }
 
             }
         ], (error) => {
-            this.chatEngine.throwError(this, 'trigger', 'auth', new Error('Something went wrong while making a request to authentication server.'), { error });
+            if(error) {
+
+                this.chatEngine.throwError(this, 'trigger', 'auth', new Error('Something went wrong while making a request to authentication server.'), { error });
+            }else {
+                complete();
+            }
         });
 
     }

--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -567,10 +567,8 @@ class Chat extends Emitter {
      @private
      @param {Object} state The new state {@link Me} will have within this {@link User}
      */
-    setState(state) {
-        this.chatEngine.pubnub.setState({ state, channels: [this.chatEngine.global.channel] }, () => {
-            // handle status, response
-        });
+    setState(state, callback) {
+        this.chatEngine.pubnub.setState({ state, channels: [this.chatEngine.global.channel] }, callback);
     }
 
     /**

--- a/src/components/me.js
+++ b/src/components/me.js
@@ -56,13 +56,13 @@ class Me extends User {
      * // update state
      * me.update({value: true});
      */
-    update(state) {
+    update(state, callback = () => {}) {
 
         // run the root update function
         super.update(state);
 
         // publish the update over the global channel
-        this.chatEngine.global.setState(state);
+        this.chatEngine.global.setState(state, callback);
 
     }
 

--- a/src/components/session.js
+++ b/src/components/session.js
@@ -102,8 +102,6 @@ class Session extends Emitter {
      */
     join(chat) {
 
-        console.log('join called for', chat.channel)
-
         // don't rebroadcast chats in session we've already heard about
         if (!this.chats[chat.group] || !this.chats[chat.group][chat.channel]) {
             this.sync.emit('$.session.notify.chat.join', { subject: chat.objectify() });

--- a/src/components/session.js
+++ b/src/components/session.js
@@ -102,6 +102,8 @@ class Session extends Emitter {
      */
     join(chat) {
 
+        console.log('join called for', chat.channel)
+
         // don't rebroadcast chats in session we've already heard about
         if (!this.chats[chat.group] || !this.chats[chat.group][chat.channel]) {
             this.sync.emit('$.session.notify.chat.join', { subject: chat.objectify() });

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -130,8 +130,6 @@ class User extends Emitter {
 
         if (!this._stateSet) {
 
-            console.log('getting user_state for', this.uuid)
-
             this.chatEngine.request('get', 'user_state', {
                 user: this.uuid
             }).then((res) => {

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -130,6 +130,8 @@ class User extends Emitter {
 
         if (!this._stateSet) {
 
+            console.log('getting user_state for', this.uuid)
+
             this.chatEngine.request('get', 'user_state', {
                 user: this.uuid
             }).then((res) => {

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -43,7 +43,7 @@ class User extends Emitter {
          */
         this.state = {};
 
-        this._stateFetched = false;
+        this._stateSet = false;
 
         this._stateInProgress = false;
 
@@ -103,11 +103,14 @@ class User extends Emitter {
     /**
      * @private
      * @param {Object} state The new state for the user
-     * @param {Chat} chat Chatroom to retrieve state from
      */
     update(state) {
+
         let oldState = this.state || {};
         this.state = Object.assign(oldState, state);
+
+        this._stateSet = true;
+
     }
 
     /**
@@ -123,16 +126,15 @@ class User extends Emitter {
     Get stored user state from remote server.
     @private
     */
-    _getState(callback) {
+    _getStoredState(callback) {
 
-        if (!this._stateFetched) {
+        if (!this._stateSet) {
 
             this.chatEngine.request('get', 'user_state', {
                 user: this.uuid
             }).then((res) => {
 
                 this.assign(res.data);
-                this._stateFetched = true;
 
                 callback(this.state);
 

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -41,11 +41,9 @@ class User extends Emitter {
          * // State
          * let state = user.state;
          */
-        this.state = {};
+        this.state = state;
 
         this._stateSet = false;
-
-        this._stateInProgress = false;
 
         /**
          * Feed is a Chat that only streams things a User does, like
@@ -93,8 +91,10 @@ class User extends Emitter {
             chatEngine.users[uuid] = this;
         }
 
-        // update this user's state in it's created context
-        this.assign(state);
+        if(Object.keys(state).length) {
+            // update this user's state in it's created context
+            this.assign(state);
+        }
 
         return this;
 
@@ -135,7 +135,6 @@ class User extends Emitter {
             }).then((res) => {
 
                 this.assign(res.data);
-
                 callback(this.state);
 
             }).catch((err) => {

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -91,7 +91,7 @@ class User extends Emitter {
             chatEngine.users[uuid] = this;
         }
 
-        if(Object.keys(state).length) {
+        if (Object.keys(state).length) {
             // update this user's state in it's created context
             this.assign(state);
         }

--- a/src/modules/emitter.js
+++ b/src/modules/emitter.js
@@ -195,7 +195,7 @@ class Emitter extends RootEmitter {
                 // the user doesn't exist, create it
                 payload.sender = new this.chatEngine.User(payload.sender);
 
-                payload.sender._getState(() => {
+                payload.sender._getStoredState(() => {
                     complete();
                 });
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -705,6 +705,54 @@ describe('invite', () => {
 
 });
 
+describe('state', () => {
+
+    beforeEach(reset);
+    beforeEach(createChatEngine);
+    beforeEach(createChatEngineYou);
+
+    it('should get previously set state', function shouldGetState(done) {
+
+        this.timeout(20000)
+
+        let doneCalled = false;
+
+        ChatEngine.on('$.online.*', (payload) => {
+
+            if(payload.user.uuid == ChatEngineYou.me.uuid && !doneCalled) {
+
+                assert.equal(payload.user.state.works, true);
+                doneCalled = true;
+                done();
+            }
+
+        });
+
+    });
+
+    it('should get state update', function shouldGetStateUpdate(done) {
+
+        this.timeout(20000)
+
+        let doneCalled = false;
+
+        ChatEngine.on('$.state', (payload) => {
+
+            if(payload.user.uuid == ChatEngineYou.me.uuid && !doneCalled) {
+
+                assert.equal(payload.user.state.newParam, true);
+                doneCalled = true;
+                done();
+            }
+
+        });
+
+        ChatEngineYou.me.update({newParam: true});
+
+    });
+
+});
+
 describe('memory', () => {
 
     beforeEach(reset);

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -741,7 +741,8 @@ describe('state', () => {
 
             if (payload.user.uuid === ChatEngineYou.me.uuid && !doneCalled) {
 
-                if(payload.user.state.newParam && payload.user.state.newParam  == true) {
+                if(payload.user.state.newParam && payload.user.state.newParam  == true && !doneCalled) {
+                    doneCalled = true;
                     done();
                 }
             }

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -741,7 +741,7 @@ describe('state', () => {
 
             if (payload.user.uuid === ChatEngineYou.me.uuid && !doneCalled) {
 
-                if(payload.user.state.newParam && payload.user.state.newParam  == true && !doneCalled) {
+                if (payload.user.state.newParam && payload.user.state.newParam === true && !doneCalled) {
                     doneCalled = true;
                     done();
                 }

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -741,9 +741,9 @@ describe('state', () => {
 
             if (payload.user.uuid === ChatEngineYou.me.uuid && !doneCalled) {
 
-                assert.equal(payload.user.state.newParam, true);
-                doneCalled = true;
-                done();
+                if(payload.user.state.newParam && payload.user.state.newParam  == true) {
+                    done();
+                }
             }
 
         });

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -122,7 +122,7 @@ function createChatEngineHistory(done) {
         publishKey: pubkey,
         subscribeKey: subkey
     }, {
-        globalChannel: 'global',
+        globalChannel: 'g',
         throwErrors: true
     });
     ChatEngineHistory.connect(yousername, { works: true }, yousername);
@@ -407,6 +407,7 @@ describe('history', () => {
                 limit: 50
             }).on('tester', (a) => {
 
+                assert(a.sender.state.works)
                 assert(a.timetoken);
                 assert.equal(a.event, 'tester');
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -407,7 +407,7 @@ describe('history', () => {
                 limit: 50
             }).on('tester', (a) => {
 
-                assert(a.sender.state.works)
+                assert(a.sender.state.works);
                 assert(a.timetoken);
                 assert.equal(a.event, 'tester');
 
@@ -714,13 +714,13 @@ describe('state', () => {
 
     it('should get previously set state', function shouldGetState(done) {
 
-        this.timeout(20000)
+        this.timeout(20000);
 
         let doneCalled = false;
 
         ChatEngine.on('$.online.*', (payload) => {
 
-            if(payload.user.uuid == ChatEngineYou.me.uuid && !doneCalled) {
+            if (payload.user.uuid === ChatEngineYou.me.uuid && !doneCalled) {
 
                 assert.equal(payload.user.state.works, true);
                 doneCalled = true;
@@ -733,13 +733,13 @@ describe('state', () => {
 
     it('should get state update', function shouldGetStateUpdate(done) {
 
-        this.timeout(20000)
+        this.timeout(20000);
 
         let doneCalled = false;
 
         ChatEngine.on('$.state', (payload) => {
 
-            if(payload.user.uuid == ChatEngineYou.me.uuid && !doneCalled) {
+            if (payload.user.uuid === ChatEngineYou.me.uuid && !doneCalled) {
 
                 assert.equal(payload.user.state.newParam, true);
                 doneCalled = true;
@@ -748,7 +748,7 @@ describe('state', () => {
 
         });
 
-        ChatEngineYou.me.update({newParam: true});
+        ChatEngineYou.me.update({ newParam: true });
 
     });
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -129,6 +129,9 @@ function createChatEngineHistory(done) {
     ChatEngineHistory.on('$.ready', () => {
         done();
     });
+    ChatEngineHistory.onAny((a) => {
+        console.log(a)
+    })
 
 }
 
@@ -407,7 +410,7 @@ describe('history', () => {
                 limit: 50
             }).on('tester', (a) => {
 
-                assert(a.sender.state.works);
+                assert.equal(a.sender.state.works, true);
                 assert(a.timetoken);
                 assert.equal(a.event, 'tester');
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -129,9 +129,6 @@ function createChatEngineHistory(done) {
     ChatEngineHistory.on('$.ready', () => {
         done();
     });
-    ChatEngineHistory.onAny((a) => {
-        console.log(a)
-    })
 
 }
 
@@ -589,7 +586,7 @@ describe('remote chat list', () => {
     beforeEach(createChatEngineClone);
     beforeEach(createChatEngineSync);
 
-    it('should be get notified of new chats', function getNotifiedOfNewChats(done) {
+    it('should be notified of new chats', function getNotifiedOfNewChats(done) {
 
         let newChannel = 'sync-chat' + new Date().getTime();
 


### PR DESCRIPTION
```_stateFetched``` was looking to see if we had gotten the state previously to avoid redundancy. However it was only being set if we queried the Functions endpoint. HereNow also fetches state, and that should qualify as ```_stateFetched``` as well.

This pull makes sure state is fetched only once per user. New state updates will come in via presence events.