### PR TITLE
Added missing curly braces

### DIFF
--- a/docs/tutorial-build.html
+++ b/docs/tutorial-build.html
@@ -102,13 +102,13 @@ module.exports = (config) => {
 
     return {
         middleware: {
-            emit:
+            emit: {
                 message: (payload, next) => {
                     payload.sentTime = new Date();
                     next(err, payload);
                 }
             },
-            on:
+            on: {
                 message: (payload, next) => {
                     payload.receiveTime = new Date();
                     next(err, payload);


### PR DESCRIPTION
I was working on a custom plugin and noticed that the Middleware example had an issue with missing curly braces.