### PR TITLE
Chat 280/validate remote chat list

### DIFF
--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -685,6 +685,7 @@ describe('remote chat list', () => {
         });
 
         syncChat = new ChatEngineClone.Chat(newChannel3);
+        syncChat.objectify();
 
         setTimeout(() => {
             ChatEngineSync.me.session.chats.custom[`${globalChannel}#chat#public.#${newChannel3}`].leave();

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -645,6 +645,53 @@ describe('remote chat list', () => {
 
     });
 
+    it('should leave $me.session.chats.custom and not return upon user reconnect', function syncLeaveChat(done) {
+
+        this.timeout(15000);
+
+        let newChannel3 = 'sync-chat3' + new Date().getTime();
+        let syncChat;
+
+        ChatEngineSync.me.session.on('$.chat.leave', (payload) => {
+            if (payload.chat.channel.indexOf(newChannel3) > -1) {
+                // Reconnect to CE with same user
+                ChatEngineSync = require('../../src/index.js').create({
+                    publishKey: pubkey,
+                    subscribeKey: subkey
+                }, {
+                    globalChannel,
+                    enableSync: true,
+                    throwErrors: true
+                });
+
+                ChatEngineSync.connect(username, { works: false }, username);
+
+                let groupRestored = false;
+
+                ChatEngineSync.on('$.group.restored', () => {
+                    assert.isObject(ChatEngineSync.me.session.chats['system']);
+                    assert.equal(ChatEngineSync.me.session.chats['custom'], undefined);
+                    groupRestored = true;
+                });
+
+                // Await the population of $me.session.chats from enableSync
+                setTimeout(() => {
+                    if (groupRestored === true) {
+                        done();
+                    }
+                }, 5000)
+            }
+
+        });
+
+        syncChat = new ChatEngineClone.Chat(newChannel3);
+
+        setTimeout(() => {
+            ChatEngineSync.me.session.chats["custom"][`${globalChannel}#chat#public.#${newChannel3}`].leave();
+        }, 5000);
+
+    });
+
 });
 
 describe('invite', () => {

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -669,8 +669,8 @@ describe('remote chat list', () => {
                 let groupRestored = false;
 
                 ChatEngineSync.on('$.group.restored', () => {
-                    assert.isObject(ChatEngineSync.me.session.chats['system']);
-                    assert.equal(ChatEngineSync.me.session.chats['custom'], undefined);
+                    assert.isObject(ChatEngineSync.me.session.chats.system);
+                    assert.equal(ChatEngineSync.me.session.chats.custom, undefined);
                     groupRestored = true;
                 });
 
@@ -679,7 +679,7 @@ describe('remote chat list', () => {
                     if (groupRestored === true) {
                         done();
                     }
-                }, 5000)
+                }, 5000);
             }
 
         });
@@ -687,7 +687,7 @@ describe('remote chat list', () => {
         syncChat = new ChatEngineClone.Chat(newChannel3);
 
         setTimeout(() => {
-            ChatEngineSync.me.session.chats["custom"][`${globalChannel}#chat#public.#${newChannel3}`].leave();
+            ChatEngineSync.me.session.chats.custom[`${globalChannel}#chat#public.#${newChannel3}`].leave();
         }, 5000);
 
     });


### PR DESCRIPTION
- Ensure that when a user explicitly leaves a chat (w/ enableSync: true) and reconnects, that the previously left channel is not present in session.chats