### PR TITLE
Refactor filters and augmentation functions to work in plugin structure

### DIFF
--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -1,7 +1,10 @@
+
 const waterfall = require('async/waterfall');
 const Emitter = require('../modules/emitter');
 const Event = require('../components/event');
 const Search = require('../components/search');
+
+const augmentChat = require('../plugins/augment/chat');
 
 /**
  This is the root {@link Chat} class that represents a chat room
@@ -28,6 +31,8 @@ class Chat extends Emitter {
         this.chatEngine = chatEngine;
 
         this.name = 'Chat';
+
+        this.plugin(augmentChat(this));
 
         /**
         * Classify the chat within some group, Valid options are 'system', 'fixed', or 'custom'.

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -127,6 +127,7 @@ class Search extends Emitter {
                     if (!reject) {
                         this.needleCount += 1;
                     }
+
                     cb();
 
                 });
@@ -138,10 +139,12 @@ class Search extends Emitter {
         };
 
         this.next = () => {
-            if (this.hasMore) {
-                this.maxPage = this.maxPage + this.config.pages;
 
+            if (this.hasMore) {
+
+                this.maxPage = this.maxPage + this.config.pages;
                 this.find();
+
             } else {
                 this._emit('$.search.finish');
             }
@@ -155,13 +158,14 @@ class Search extends Emitter {
                 response.messages.reverse();
 
                 eachSeries(response.messages, this.triggerHistory, () => {
+
                     if (this.hasMore && this.numPage === this.maxPage) {
                         this._emit('$.search.pause');
                     } else if (this.hasMore && (this.needleCount < this.config.limit || this.messagesBetweenTimetokens)) {
-
                         this.numPage += 1;
                         this.find();
                     } else {
+
                         if (this.needleCount >= this.config.limit && !this.messagesBetweenTimetokens) {
                             this.hasMore = false;
                         }
@@ -171,7 +175,9 @@ class Search extends Emitter {
                          * @event Search#$"."search"."finish
                          */
                         this._emit('$.search.finish');
+
                     }
+
                 });
             });
 
@@ -179,11 +185,11 @@ class Search extends Emitter {
         };
 
         if (this.config.event) {
-            this.plugins.shift(eventFilter(this.config.event));
+            this.plugins.unshift(eventFilter(this.config.event));
         }
 
         if (this.config.sender) {
-            this.plugins.shift(senderFilter(this.config.sender));
+            this.plugins.unshift(senderFilter(this.config.sender));
         }
 
         /**

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -123,6 +123,8 @@ class User extends Emitter {
     */
     _getStoredState(callback) {
 
+        console.log('getting stored state');
+
         if (!this._stateSet) {
 
             this.chatEngine.request('get', 'user_state', {

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -123,8 +123,6 @@ class User extends Emitter {
     */
     _getStoredState(callback) {
 
-        console.log('getting stored state');
-
         if (!this._stateSet) {
 
             this.chatEngine.request('get', 'user_state', {

--- a/src/modules/emitter.js
+++ b/src/modules/emitter.js
@@ -173,6 +173,7 @@ class Emitter extends RootEmitter {
             if (reject) {
                 done(reject);
             } else {
+
                 // emit this event to any listener
                 this._emit(event, pluginResponse);
                 done(null, event, pluginResponse);

--- a/src/plugins/augment/chat.js
+++ b/src/plugins/augment/chat.js
@@ -1,0 +1,20 @@
+module.exports = (chat) => {
+
+    return {
+        middleware: {
+            on: {
+                '*': (payload, next) => {
+
+                    // restore chat in payload
+                    if (!payload.chat) {
+                        payload.chat = chat;
+                    }
+
+                    next(null, payload);
+                }
+            }
+        }
+    };
+
+};
+

--- a/src/plugins/augment/sender.js
+++ b/src/plugins/augment/sender.js
@@ -1,0 +1,29 @@
+module.exports = (chatEngine) => {
+
+    return {
+        middleware: {
+            on: {
+                '*': (payload, next) => {
+
+                    // if we should try to restore the sender property
+                    if (payload.sender && typeof payload.sender === 'string') {
+
+                        // get the user from ChatEngine
+                        payload.sender = new chatEngine.User(payload.sender);
+
+                        payload.sender._getStoredState(() => {
+                            next(null, payload);
+                        });
+
+                    } else {
+                        // there's no "sender" in this object, move on
+                        next(null, payload);
+                    }
+
+                }
+            }
+        }
+    };
+
+};
+

--- a/src/plugins/filter/event.js
+++ b/src/plugins/filter/event.js
@@ -1,0 +1,15 @@
+module.exports = (event) => {
+    return {
+        middleware: {
+            on: {
+                '*': (payload, next) => {
+
+                    let matches = payload && payload.event && payload.event === event;
+
+                    next(!matches, payload);
+                }
+            }
+        }
+    };
+};
+

--- a/src/plugins/filter/sender.js
+++ b/src/plugins/filter/sender.js
@@ -1,0 +1,12 @@
+module.exports = (user) => {
+    return {
+        middleware: {
+            on: {
+                '*': (payload, next) => {
+                    let matches = payload && payload.sender && payload.sender.uuid === user.uuid;
+                    next(!matches, payload);
+                }
+            }
+        }
+    };
+};

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -400,6 +400,13 @@ describe('history', () => {
 
         let chatHistory = new ChatEngineHistory.Chat('chat-history');
 
+        let i = 0;
+        while(i < 200) {
+            chatHistory.emit('tester', {works: true});
+            chatHistory.emit('not-tester', {works: false});
+            i++;
+        }
+
         chatHistory.on('$.connected', () => {
 
             let search = chatHistory.search({
@@ -435,8 +442,7 @@ describe('history', () => {
 
             let search = chatHistory2.search({
                 event: 'tester',
-                limit: 200,
-                pages: 11
+                limit: 200
             }).on('tester', (a) => {
 
                 assert(a.timetoken);
@@ -462,9 +468,9 @@ describe('history', () => {
         chatHistory.on('$.connected', () => {
 
             chatHistory.search({
-                limit: 10,
-                pages: 12
-            }).on('tester', (a) => {
+                limit: 10
+            })
+            .on('tester', (a) => {
 
                 assert.equal(a.event, 'tester');
 
@@ -487,8 +493,7 @@ describe('history', () => {
         chatHistory.on('$.connected', () => {
             let search = chatHistory.search({
                 event: 'tester',
-                limit: 10,
-                pages: 13
+                limit: 10
             }).on('tester', (a) => {
                 timetokens.push(a.timetoken);
             }).on('$.search.finish', () => {

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -469,8 +469,7 @@ describe('history', () => {
 
             chatHistory.search({
                 limit: 10
-            })
-            .on('tester', (a) => {
+            }).on('tester', (a) => {
 
                 assert.equal(a.event, 'tester');
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -400,12 +400,12 @@ describe('history', () => {
 
         let chatHistory = new ChatEngineHistory.Chat('chat-history');
 
-        let i = 0;
-        while(i < 200) {
-            chatHistory.emit('tester', {works: true});
-            chatHistory.emit('not-tester', {works: false});
-            i++;
-        }
+        // let i = 0;
+        // while(i < 200) {
+        //     chatHistory.emit('tester', {works: true, count: i});
+        //     chatHistory.emit('not-tester', {works: false, count: i});
+        //     i++;
+        // }
 
         chatHistory.on('$.connected', () => {
 

--- a/test/unit/modules/emitter.test.js
+++ b/test/unit/modules/emitter.test.js
@@ -47,7 +47,7 @@ describe('#emitter', () => {
         };
 
         emitterInstance.plugin(plugin);
-        assert(emitterInstance.plugins.length === 1, 'plugin works!');
+        assert(emitterInstance.plugins.length === 2, 'plugin works!');
         done();
     });
 
@@ -90,7 +90,7 @@ describe('#emitter', () => {
 
         emitterInstance.plugin(plugin());
 
-        assert(emitterInstance.plugins.length === 1, 'plugin works!');
+        assert(emitterInstance.plugins.length === 2, 'plugin works!');
         assert(emitterInstance.demo_plugin.get('stringKey') === 'plugin state', 'got the expected value');
 
         done();


### PR DESCRIPTION
This refactors the way "augmentation" works for message payload. Previously this was done with conditionals, but I've opted to use the plugin structure here instead.

- Message augmentation (payload.sender, payload.user, etc) is done via internal plugins found in ```/plugins```
- Allows us to reject messages in the plugin queue before they are emitted by history (cause of excess user_state calls)
- Makes augmentation modular for future improvement