### PR TITLE
Chat 354 Double State Fix

### DIFF
--- a/guide/concepts/pubnub/usage.md
+++ b/guide/concepts/pubnub/usage.md
@@ -19,7 +19,7 @@ User connects to ChatEngine See (#connect)
 'blocks.join': 3 // global + direct + feed
 ```
 
-User updates own state twice (see #connect) *
+@todo User updates own state twice (see #connect) *
 Makes two hereNow requests on global channel (see #connect)
 
 * One state call is duplicated (this is a bug)
@@ -62,7 +62,7 @@ Two users each bootstrap their own client
 'subscribe.heartbeat': 18
 ```
 
-Each user updates state twice.
+@todo Each user updates state twice.
 
 ```
 'presence.heartbeat': 4
@@ -85,6 +85,50 @@ history: 4
 
 ```
 publish: 6
+```
+
+## 10 users join 1 group and send 10 messages each
+
+10 users connect
+
+```
+'blocks.bootstrap': 10
+'blocks.user_read': 10
+'blocks.user_write': 10
+'blocks.group': 10
+```
+
+Each user granted on global, direct, feed, and the new group chat.
+
+```
+'blocks.grant': 40
+'blocks.join': 40
+```
+
+@todo Unclear...
+
+```
+'presence.state': 40
+```
+
+Messages are received (but are packed together).
+
+```
+'subscribe': 63
+```
+
+Presence Heartbeat
+
+@todo Presence here_now is called in global chat twice per user.
+
+```
+'presence.heartbeat': 20
+```
+
+10 users publish 10 messages
+
+```
+publish: 100
 ```
 
 # Usage

--- a/guide/concepts/pubnub/usage.md
+++ b/guide/concepts/pubnub/usage.md
@@ -1,0 +1,90 @@
+### THIS DOES NOT REFLECT TRUE CONDITONAL EXECUTION
+
+That is what code is for.
+
+# Example Scenarios:
+
+-
+
+
+
+# Usage
+
+## Connect
+
+- handshake() - happens automatically
+    - PubNub function bootstrap
+        - executes auth policy
+        - performs grant
+            - grants on global
+            - global presence
+            - my channel
+            - my read
+            - my write
+    - PubNub function user_read
+        - grants everbody access on feed channel
+    - PubNub function user_write
+        - grants everybody access on direct channel
+    - PubNub function group
+        - grants me access to
+        - rooms, system, custom
+    - makes a new global chat
+        - see #chat
+    - makes session calls (if enableSync is true) (see #session)
+    - creates a new user for self (see #user)
+        - PubNub setState() with provided state on global channel
+    - calls PubNub hereNow() to get user updates on global channel
+
+## User
+
+- automatic
+    - PubNub function user_state
+        - attempts to get state from server if state has not been set through other means
+- update()
+    - PubNub setState()
+        - received by all other users in global channel
+
+## Chat
+
+- connect()
+    - PubNub function grant
+        - gives user permission to chat channel
+    - PubNub function join
+        - adds channel to channel group
+    - PubNub function get chat
+        - tries to get chat metadata
+    - if enableMeta
+        - if no chat metadata
+            - PubNub function set chat metadata
+    - if enableSync
+        - PubNub publishes a message
+            - received by self in multiple windows
+    - PubNub hereNow()
+    - PubNub hereNow()
+        - 5 seconds later
+- publish()
+    - PubNub publish to chat channel
+- search()
+    - see #search
+- invite()
+    - User must be created. See (#user)
+    - PubNub function invite
+    - Connects to other user's direct channel (see #chat)
+    - PubNub publish an invitation message to their channel
+- leave()
+    - Unsubscribes from channel
+    - PubNub function leave
+    - PubNub publish leave
+
+## Search
+- automatic
+    - calls PubNub.history() a max of 10 times and limit of 100
+        - this can happen as little as 1 time depending on inputs
+    - can be called again with search.next()
+    - if message is from user that is offline, user is created. See #user
+
+# Session
+
+- automatic
+    - creates a new chat for session (see #chat)
+    - PubNub.channelGroups.listChannels() to get current channels

--- a/guide/concepts/pubnub/usage.md
+++ b/guide/concepts/pubnub/usage.md
@@ -6,11 +6,7 @@ That is what code is for.
 
 Each scenario is 30 seconds long
 
-## One user connects
-
-This is an example of a single user connecting to the system
-
-### 10 PubNub Functions calls
+## One user connects. This is an example of a single user connecting to the system
 
 User connects to ChatEngine See (#connect)
 
@@ -23,8 +19,6 @@ User connects to ChatEngine See (#connect)
 'blocks.join': 3 // global + direct + feed
 ```
 
-### 4 Presence calls
-
 User updates own state twice (see #connect) *
 Makes two hereNow requests on global channel (see #connect)
 
@@ -35,15 +29,13 @@ Makes two hereNow requests on global channel (see #connect)
 'presence.heartbeat': 2 // calls hereNow twice
 ```
 
-### 1 Subscribe
-
 Subscribes to global channel
 
 ```
 'subscribe.heartbeat': 1
 ```
 
-# Two users invite each other into private channels and call search twice. They each send two messages in private chat.
+## Two users invite each other into private channels and call search twice. They each send two messages in private chat.
 
 Two users each bootstrap their own client
 

--- a/guide/concepts/pubnub/usage.md
+++ b/guide/concepts/pubnub/usage.md
@@ -160,7 +160,7 @@ publish: 100
 
 ## User
 
-- automatic
+- on creation (automatic)
     - PubNub function user_state
         - attempts to get state from server if state has not been set through other means
 - update()
@@ -169,7 +169,7 @@ publish: 100
 
 ## Chat
 
-- connect()
+- automatic on connect() (happens 3 times for global, feed, direct)
     - PubNub function grant
         - gives user permission to chat channel
     - PubNub function join
@@ -182,8 +182,8 @@ publish: 100
     - if enableSync
         - PubNub publishes a message
             - received by self in multiple windows
-    - PubNub hereNow()
-    - PubNub hereNow()
+    - PubNub hereNow() (global only)
+    - PubNub hereNow() (global only)
         - 5 seconds later
 - publish()
     - PubNub publish to chat channel

--- a/guide/concepts/pubnub/usage.md
+++ b/guide/concepts/pubnub/usage.md
@@ -4,9 +4,96 @@ That is what code is for.
 
 # Example Scenarios:
 
--
+Each scenario is 30 seconds long
 
+## One user connects
 
+This is an example of a single user connecting to the system
+
+### 10 PubNub Functions calls
+
+User connects to ChatEngine See (#connect)
+
+```
+'blocks.bootstrap': 1 // user
+'blocks.user_read': 1 // user
+'blocks.user_write': 1 // user
+'blocks.group': 1 // user
+'blocks.grant': 3 // global + direct + feed
+'blocks.join': 3 // global + direct + feed
+```
+
+### 4 Presence calls
+
+User updates own state twice (see #connect) *
+Makes two hereNow requests on global channel (see #connect)
+
+* One state call is duplicated (this is a bug)
+
+```
+'presence.state': 2 // updates own state
+'presence.heartbeat': 2 // calls hereNow twice
+```
+
+### 1 Subscribe
+
+Subscribes to global channel
+
+```
+'subscribe.heartbeat': 1
+```
+
+# Two users invite each other into private channels and call search twice. They each send two messages in private chat.
+
+Two users each bootstrap their own client
+
+```
+'blocks.bootstrap': 2
+'blocks.user_read': 2
+'blocks.user_write': 2
+'blocks.group': 2
+```
+
+2 users (* 3 chats (global, direct, feed) + (other user's direct) + (channel I invite you to) + (channel you invite me to))
+
+```
+'blocks.grant': 12
+'blocks.join': 12
+'presence.state': 12
+```
+
+2 users * (I subscribe to my own invite + I get your invite) + 2 chats * (I publish a message + you publish a message)
+
+* 10 subscribe heartbeats here unaccounted for
+
+```
+'subscribe.heartbeat': 18
+```
+
+Each user updates state twice.
+
+```
+'presence.heartbeat': 4
+```
+
+Each user invites another (grants access)
+
+```
+'blocks.invite': 2
+```
+
+Two users call search twice
+(2 search * 2  users)
+
+```
+history: 4
+```
+
+2 users * 2 messages in private chat + (2 users * 1 invite in direct)
+
+```
+publish: 6
+```
 
 # Usage
 

--- a/src/components/me.js
+++ b/src/components/me.js
@@ -34,17 +34,6 @@ class Me extends User {
     }
 
     /**
-     * assign updates from network
-     * @private
-     */
-    assign(state) {
-        // we call "update" because calling "super.assign"
-        // will direct back to "this.update" which creates
-        // a loop of network updates
-        super.update(state);
-    }
-
-    /**
      * Update {@link Me}'s state in a {@link Chat}. All other {@link User}s
      * will be notified of this change via ```$.state```.
      * Retrieve state at any time with {@link User#state}.
@@ -58,11 +47,21 @@ class Me extends User {
      */
     update(state, callback = () => {}) {
 
-        // run the root update function
-        super.update(state);
+        // assign state values locally before broadcasting them over the network
+        this.assign(state);
 
         // publish the update over the global channel
         this.chatEngine.global.setState(state, callback);
+    }
+
+    /**
+     * assign updates from network
+     * @private
+     */
+    assign(state) {
+
+        // run the root update function
+        super.assign(state);
 
     }
 

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -96,10 +96,10 @@ class User extends Emitter {
     }
 
     /**
-     * @private
-     * @param {Object} state The new state for the user
+     this is only called from network updates
+     @private
      */
-    update(state) {
+    assign(state) {
 
         let oldState = this.state || {};
         this.state = Object.assign(oldState, state);
@@ -109,12 +109,11 @@ class User extends Emitter {
     }
 
     /**
-     this is only called from network updates
-
-     @private
+     * @private
+     * @param {Object} state The new state for the user
      */
-    assign(state) {
-        this.update(state);
+    update(state) {
+        this.assign(state);
     }
 
     /**


### PR DESCRIPTION
Previously, ChatEngine would use ```Me.update()``` manually on boot, and additionally in the ```construct()``` function within the class. This is wasteful.

Instead, the ```construct()``` calls ```Me.assign()```, which is the local version of ```update()```.