### PR TITLE
Chat-354 Only set state once

### DIFF
--- a/src/components/me.js
+++ b/src/components/me.js
@@ -34,17 +34,6 @@ class Me extends User {
     }
 
     /**
-     * assign updates from network
-     * @private
-     */
-    assign(state) {
-        // we call "update" because calling "super.assign"
-        // will direct back to "this.update" which creates
-        // a loop of network updates
-        super.update(state);
-    }
-
-    /**
      * Update {@link Me}'s state in a {@link Chat}. All other {@link User}s
      * will be notified of this change via ```$.state```.
      * Retrieve state at any time with {@link User#state}.
@@ -58,11 +47,21 @@ class Me extends User {
      */
     update(state, callback = () => {}) {
 
-        // run the root update function
-        super.update(state);
+        // assign state values locally before broadcasting them over the network
+        this.assign(state);
 
         // publish the update over the global channel
         this.chatEngine.global.setState(state, callback);
+    }
+
+    /**
+     * assign updates from network
+     * @private
+     */
+    assign(state) {
+
+        // run the root update function
+        super.assign(state);
 
     }
 

--- a/src/components/user.js
+++ b/src/components/user.js
@@ -96,10 +96,10 @@ class User extends Emitter {
     }
 
     /**
-     * @private
-     * @param {Object} state The new state for the user
+     this is only called from network updates
+     @private
      */
-    update(state) {
+    assign(state) {
 
         let oldState = this.state || {};
         this.state = Object.assign(oldState, state);
@@ -109,12 +109,11 @@ class User extends Emitter {
     }
 
     /**
-     this is only called from network updates
-
-     @private
+     * @private
+     * @param {Object} state The new state for the user
      */
-    assign(state) {
-        this.update(state);
+    update(state) {
+        this.assign(state);
     }
 
     /**


### PR DESCRIPTION
Previously, ChatEngine would use ```Me.update()``` manually on boot, and additionally in the ```construct()``` function within the class. This is wasteful.

Instead, the ```construct()``` calls ```Me.assign()```, which is the local version of ```update()```.