### PR TITLE
Fixed role of 'pages' in iterative search with configured 'limit'.

### DIFF
--- a/src/components/chat.js
+++ b/src/components/chat.js
@@ -582,7 +582,9 @@ class Chat extends Emitter {
      @param {Object} [config] Our configuration for the PubNub history request. See the [PubNub History](https://www.pubnub.com/docs/web-javascript/storage-and-history) docs for more information on these parameters.
      @param {Event} [config.event] The {@link Event} to search for.
      @param {User} [config.sender] The {@link User} who sent the message.
+     @param {Number} [config.pages=10] The maximum number of history requests which {@link ChatEngine} will do automatically to fulfill `limit` requirement.
      @param {Number} [config.limit=20] The maximum number of results to return that match search criteria. Search will continue operating until it returns this number of results or it reached the end of history. Limit will be ignored in case if both 'start' and 'end' timetokens has been passed in search configuration.
+     @param {Number} [config.count=100] The maximum number of messages which can be fetched with single history request.
      @param {Number} [config.start=0] The timetoken to begin searching between.
      @param {Number} [config.end=0] The timetoken to end searching between.
      @param {Boolean} [config.reverse=false] Search oldest messages first.

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -156,13 +156,13 @@ class Search extends Emitter {
         this.find = () => {
             this.page((response) => {
                 response.messages.reverse();
+                this.numPage += 1;
 
                 eachSeries(response.messages, this.triggerHistory, () => {
 
                     if (this.hasMore && this.numPage === this.maxPage) {
                         this._emit('$.search.pause');
                     } else if (this.hasMore && (this.needleCount < this.config.limit || this.messagesBetweenTimetokens)) {
-                        this.numPage += 1;
                         this.find();
                     } else {
 

--- a/test/integration/main.test.js
+++ b/test/integration/main.test.js
@@ -789,6 +789,25 @@ describe('history', () => {
             });
         });
     });
+
+    it('should fetch one page and wait', function emittedDescendingOrder(done) {
+
+        this.timeout(60000);
+
+        let chatHistory = new ChatEngineHistory.Chat('chat-history');
+
+        chatHistory.on('$.connected', () => {
+            let search = chatHistory.search({
+                event: 'tester',
+                count: 10,
+                pages: 1
+            }).on('$.search.pause', () => {
+
+                assert.equal(search.hasMore, true, 'potentially should be more data');
+                done();
+            });
+        });
+    });
 });
 
 describe('meta', () => {


### PR DESCRIPTION
Fixed issue because of which current `page` increased inside of condition, which prevented proper `page` limits handling in another (where `$.search.pause` expected to be emitted).