### PR TITLE
Fix authKey undefined bug. [CHAT]

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -464,6 +464,8 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
      */
     ChatEngine.reconnect = (authKey) => {
 
+        authKey = authKey || PubNub.generateUUID();
+
         if (authKey) {
             // do the whole auth flow with the new authKey
             ChatEngine.handshake(() => {
@@ -487,6 +489,8 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
     @private
     */
     ChatEngine.setAuth = (authKey) => {
+
+        authKey = authKey || PubNub.generateUUID();
 
         ChatEngine.pnConfig.authKey = authKey;
         ChatEngine.pubnub.setAuthKey(authKey);
@@ -516,6 +520,8 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
      */
     ChatEngine.reauthorize = (authKey) => {
 
+        authKey = authKey || PubNub.generateUUID();
+
         ChatEngine.global.once('$.disconnected', () => {
 
             ChatEngine.setAuth(authKey);
@@ -536,6 +542,8 @@ module.exports = (ceConfig = {}, pnConfig = {}) => {
      * @fires $"."connected
      */
     ChatEngine.connect = (uuid, state = {}, authKey) => {
+
+        authKey = authKey || PubNub.generateUUID();
 
         // this creates a user known as Me and
         // connects to the global chatroom

--- a/test/unit/components/event.test.js
+++ b/test/unit/components/event.test.js
@@ -11,7 +11,7 @@ describe('#event', () => {
     let event = null;
 
     beforeEach(() => {
-        chatEngineInstance = Bootstrap({ globalChannel: 'common', insecure: true }, { publishKey: 'demo', subscribeKey: 'demo' , authKey: 'demo' });
+        chatEngineInstance = Bootstrap({ globalChannel: 'common', insecure: true }, { publishKey: 'demo', subscribeKey: 'demo', authKey: 'demo' });
 
         // mock pubnub
         chatEngineInstance.pubnub = {

--- a/test/unit/components/event.test.js
+++ b/test/unit/components/event.test.js
@@ -11,7 +11,7 @@ describe('#event', () => {
     let event = null;
 
     beforeEach(() => {
-        chatEngineInstance = Bootstrap({ globalChannel: 'common', insecure: true }, { publishKey: 'demo', subscribeKey: 'demo' });
+        chatEngineInstance = Bootstrap({ globalChannel: 'common', insecure: true }, { publishKey: 'demo', subscribeKey: 'demo' , authKey: 'demo' });
 
         // mock pubnub
         chatEngineInstance.pubnub = {


### PR DESCRIPTION
- When the "reuse authKey"  [PR](https://github.com/pubnub/chat-engine/pull/391/files) was reviewed, I missed that Travis failed on itests. GH did not link back to the bad travis build :( 
- Updated bootstrap.js to properly reuse authKey
- Updated failing unittest 